### PR TITLE
Enable tabpfn classifier config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,6 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
+**/.DS_Store

--- a/tabpfn_client/remote_tabpfn_classifier.py
+++ b/tabpfn_client/remote_tabpfn_classifier.py
@@ -55,26 +55,6 @@ class RemoteTabPFNClassifier(BaseEstimator, ClassifierMixin):
         self.multiclass_decoder = multiclass_decoder
 
         self.inference_handler = inference_handler
-        self.inference_handler.config_tabpfn(
-            # model=self.model,
-            device=self.device,
-            base_path=str(self.base_path),
-            model_string=self.model_string,
-            batch_size_inference=self.batch_size_inference,
-            # fp16_inference=self.fp16_inference,
-            # inference_mode=self.inference_mode,
-            # c=self.c,
-            N_ensemble_configurations=self.N_ensemble_configurations,
-            # preprocess_transforms=self.preprocess_transforms,
-            feature_shift_decoder=self.feature_shift_decoder,
-            # normalize_with_test=self.normalize_with_test,
-            # average_logits=self.average_logits,
-            # categorical_features=self.categorical_features,
-            # optimize_metric=self.optimize_metric,
-            seed=self.seed,
-            # transformer_predict_kwargs_init=self.transformer_predict_kwargs_init,
-            multiclass_decoder=self.multiclass_decoder,
-        )
 
     def fit(self, X, y):
         self.inference_handler.fit(X, y)
@@ -83,8 +63,31 @@ class RemoteTabPFNClassifier(BaseEstimator, ClassifierMixin):
 
     def predict(self, X):
         check_is_fitted(self)
-        return self.inference_handler.predict(X)
+        return self.inference_handler.predict(X, with_proba=False, tabpfn_config=self.config)
 
     def predict_proba(self, X):
         check_is_fitted(self)
-        return self.inference_handler.predict_proba(X)
+        return self.inference_handler.predict(X, with_proba=True, tabpfn_config=self.config)
+
+    @property
+    def config(self) -> dict:
+        return {
+            # "model": self.model,
+            "device": self.device,
+            "base_path": str(self.base_path),
+            "model_string": self.model_string,
+            "batch_size_inference": self.batch_size_inference,
+            # "fp16_inference": self.fp16_inference,
+            # "inference_mode": self.inference_mode,
+            # "c": self.c,
+            "N_ensemble_configurations": self.N_ensemble_configurations,
+            # "preprocess_transforms": self.preprocess_transforms,
+            "feature_shift_decoder": self.feature_shift_decoder,
+            # "normalize_with_test": self.normalize_with_test,
+            # "average_logits": self.average_logits,
+            # "categorical_features": self.categorical_features,
+            # "optimize_metric": self.optimize_metric,
+            "seed": self.seed,
+            # "transformer_predict_kwargs_init": self.transformer_predict_kwargs_init,
+            "multiclass_decoder": self.multiclass_decoder,
+        }

--- a/tabpfn_client/remote_tabpfn_classifier.py
+++ b/tabpfn_client/remote_tabpfn_classifier.py
@@ -8,24 +8,24 @@ class RemoteTabPFNClassifier(BaseEstimator, ClassifierMixin):
 
     def __init__(
             self,
-            model=None,
-            device="cpu",
-            base_path=".",
-            model_string="",
-            batch_size_inference=4,
-            fp16_inference=False,
-            inference_mode=True,
-            c=None,
-            N_ensemble_configurations=10,
-            preprocess_transforms=("none", "power_all"),
-            feature_shift_decoder=False,
-            normalize_with_test=False,
-            average_logits=False,
-            categorical_features=tuple(),
-            optimize_metric=None,
-            seed=None,
-            transformer_predict_kwargs_init=None,
-            multiclass_decoder="permutation",
+            # model,
+            device,
+            base_path,
+            model_string,
+            batch_size_inference,
+            # fp16_inference,
+            # inference_mode,
+            # c,
+            N_ensemble_configurations,
+            # preprocess_transforms,
+            feature_shift_decoder,
+            # normalize_with_test,
+            # average_logits,
+            # categorical_features,
+            # optimize_metric,
+            seed,
+            # transformer_predict_kwargs_init,
+            multiclass_decoder,
 
             # dependency injection (for testing)
             inference_handler=InferenceClient()
@@ -35,26 +35,46 @@ class RemoteTabPFNClassifier(BaseEstimator, ClassifierMixin):
         #  In the future version, these configs will be used to create per-user TabPFNClassifier,
         #    allowing the user to setup the desired TabPFNClassifier on the server.
         # config for tabpfn
-        self.model = model
+        # self.model = model
         self.device = device
         self.base_path = base_path
         self.model_string = model_string
         self.batch_size_inference = batch_size_inference
-        self.fp16_inference = fp16_inference
-        self.inference_mode = inference_mode
-        self.c = c
+        # self.fp16_inference = fp16_inference
+        # self.inference_mode = inference_mode
+        # self.c = c
         self.N_ensemble_configurations = N_ensemble_configurations
-        self.preprocess_transforms = preprocess_transforms
+        # self.preprocess_transforms = preprocess_transforms
         self.feature_shift_decoder = feature_shift_decoder
-        self.normalize_with_test = normalize_with_test
-        self.average_logits = average_logits
-        self.categorical_features = categorical_features
-        self.optimize_metric = optimize_metric
+        # self.normalize_with_test = normalize_with_test
+        # self.average_logits = average_logits
+        # self.categorical_features = categorical_features
+        # self.optimize_metric = optimize_metric
         self.seed = seed
-        self.transformer_predict_kwargs_init = transformer_predict_kwargs_init
+        # self.transformer_predict_kwargs_init = transformer_predict_kwargs_init
         self.multiclass_decoder = multiclass_decoder
 
         self.inference_handler = inference_handler
+        self.inference_handler.config_tabpfn(
+            # model=self.model,
+            device=self.device,
+            base_path=str(self.base_path),
+            model_string=self.model_string,
+            batch_size_inference=self.batch_size_inference,
+            # fp16_inference=self.fp16_inference,
+            # inference_mode=self.inference_mode,
+            # c=self.c,
+            N_ensemble_configurations=self.N_ensemble_configurations,
+            # preprocess_transforms=self.preprocess_transforms,
+            feature_shift_decoder=self.feature_shift_decoder,
+            # normalize_with_test=self.normalize_with_test,
+            # average_logits=self.average_logits,
+            # categorical_features=self.categorical_features,
+            # optimize_metric=self.optimize_metric,
+            seed=self.seed,
+            # transformer_predict_kwargs_init=self.transformer_predict_kwargs_init,
+            multiclass_decoder=self.multiclass_decoder,
+        )
 
     def fit(self, X, y):
         self.inference_handler.fit(X, y)

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -1,7 +1,7 @@
 ## testing
 #protocol: "http"
 #host: "0.0.0.0"
-#port: "8000"
+#port: "80"
 
 # production
 protocol: "https"

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -48,11 +48,6 @@ endpoints:
     methods: [ "POST" ]
     description: "Predict"
 
-  predict_proba:
-    path: "/predict_proba/"
-    methods: [ "POST" ]
-    description: "Predict probability"
-
   get_data_summary:
     path: "/get_data_summary/"
     methods: [ "GET" ]

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -160,17 +160,6 @@ class InferenceClient(ServiceClientWrapper):
     def __init__(self, service_client=ServiceClient()):
         super().__init__(service_client)
         self.last_train_set_uid = None
-        self.tabpfn_config = {}
-
-    def config_tabpfn(self, **kwargs):
-        """
-        Configure TabPFN model.
-
-        If no kwargs is provided, the default config will be used.
-        note: this doesn't check if the keyword nor the value is valid
-        """
-
-        self.tabpfn_config = dict(kwargs)
 
     def fit(self, X, y) -> None:
         if not self.service_client.is_initialized:
@@ -178,18 +167,10 @@ class InferenceClient(ServiceClientWrapper):
 
         self.last_train_set_uid = self.service_client.upload_train_set(X, y)
 
-    def predict(self, X):
+    def predict(self, X, with_proba: bool = True, tabpfn_config: dict = None):
         return self.service_client.predict(
-            tabpfn_config=self.tabpfn_config,
             train_set_uid=self.last_train_set_uid,
             x_test=X,
+            with_proba=with_proba,
+            tabpfn_config=tabpfn_config,
         )
-
-    def predict_proba(self, X):
-        return self.service_client.predict_proba(
-            tabpfn_config=self.tabpfn_config,
-            train_set_uid=self.last_train_set_uid,
-            x_test=X,
-        )
-
-

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -152,13 +152,25 @@ class UserDataClient(ServiceClientWrapper):
 class InferenceClient(ServiceClientWrapper):
     """
     Wrapper of ServiceClient to handle inference, including:
+    - TabPFN model configuration
     - fitting
     - prediction
     """
 
-    def __init__(self, service_client = ServiceClient()):
+    def __init__(self, service_client=ServiceClient()):
         super().__init__(service_client)
         self.last_train_set_uid = None
+        self.tabpfn_config = {}
+
+    def config_tabpfn(self, **kwargs):
+        """
+        Configure TabPFN model.
+
+        If no kwargs is provided, the default config will be used.
+        note: this doesn't check if the keyword nor the value is valid
+        """
+
+        self.tabpfn_config = dict(kwargs)
 
     def fit(self, X, y) -> None:
         if not self.service_client.is_initialized:
@@ -168,14 +180,16 @@ class InferenceClient(ServiceClientWrapper):
 
     def predict(self, X):
         return self.service_client.predict(
+            tabpfn_config=self.tabpfn_config,
             train_set_uid=self.last_train_set_uid,
-            x_test=X
+            x_test=X,
         )
 
     def predict_proba(self, X):
         return self.service_client.predict_proba(
+            tabpfn_config=self.tabpfn_config,
             train_set_uid=self.last_train_set_uid,
-            x_test=X
+            x_test=X,
         )
 
 

--- a/tabpfn_client/tests/integration/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/integration/test_tabpfn_classifier.py
@@ -50,7 +50,7 @@ class TestTabPFNClassifier(unittest.TestCase):
         # mock prediction
         mock_server.router.post(mock_server.endpoints.predict.path).respond(
             200,
-            json={"y_pred": LocalTabPFNClassifier().fit(self.X_train, self.y_train).predict(self.X_test).tolist()}
+            json={"res": LocalTabPFNClassifier().fit(self.X_train, self.y_train).predict(self.X_test).tolist()}
         )
         pred = tabpfn.predict(self.X_test)
         self.assertEqual(pred.shape[0], self.X_test.shape[0])
@@ -78,7 +78,7 @@ class TestTabPFNClassifier(unittest.TestCase):
         dummy_pred = "content doesn't matter"
         mock_server.router.post(mock_server.endpoints.predict.path).respond(
             200,
-            json={"y_pred": dummy_pred}
+            json={"res": dummy_pred}
         )
         pred = tabpfn.predict(self.X_test)
 

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -55,7 +55,7 @@ class TestServiceClient(unittest.TestCase):
 
         self.client.upload_train_set(self.X_train, self.y_train)
 
-        dummy_result = {"y_pred": [1, 2, 3]}
+        dummy_result = {"res": [1, 2, 3]}
         mock_server.router.post(mock_server.endpoints.predict.path).respond(
             200, json=dummy_result)
 
@@ -63,4 +63,4 @@ class TestServiceClient(unittest.TestCase):
             train_set_uid=dummy_json["train_set_uid"],
             x_test=self.X_test
         )
-        self.assertTrue(np.array_equal(pred, dummy_result["y_pred"]))
+        self.assertTrue(np.array_equal(pred, dummy_result["res"]))

--- a/tabpfn_client/tests/unit/test_remote_tabpfn_classifier.py
+++ b/tabpfn_client/tests/unit/test_remote_tabpfn_classifier.py
@@ -25,7 +25,17 @@ class TestRemoteTabPFNClassifier(unittest.TestCase):
         self.mock_client.is_initialized.return_value = True
         inference_handler = InferenceClient(service_client=self.mock_client)
 
-        self.remote_tabpfn = RemoteTabPFNClassifier(inference_handler=inference_handler)
+        self.remote_tabpfn = RemoteTabPFNClassifier(
+            device="cpu",
+            base_path=".",
+            model_string="",
+            batch_size_inference=4,
+            N_ensemble_configurations=4,
+            feature_shift_decoder=False,
+            seed=None,
+            multiclass_decoder="permutation",
+            inference_handler=inference_handler
+        )
 
     def tearDown(self):
         patch.stopall()

--- a/tabpfn_client/tests/unit/test_service_wrapper.py
+++ b/tabpfn_client/tests/unit/test_service_wrapper.py
@@ -290,45 +290,45 @@ class TestInferenceClient(unittest.TestCase):
         # mock predict response
         mock_server.router.post(mock_server.endpoints.predict.path).respond(
             200,
-            json={"y_pred": [0]}
+            json={"res": [0]}
         )
 
         # assert no exception is raised
         tabpfn_config = {"dummy_config": "dummy_value"}
-        self.inference_client.config_tabpfn(**tabpfn_config)
-        self.assertEqual([0], self.inference_client.predict(self.dummy_x))
+        self.assertEqual([0], self.inference_client.predict(
+            self.dummy_x, with_proba=False, tabpfn_config=tabpfn_config)
+        )
 
     @with_mock_server()
     def test_predict_with_default_tabpfn_config(self, mock_server):
         # mock predict response
         mock_server.router.post(mock_server.endpoints.predict.path).respond(
             200,
-            json={"y_pred": [0]}
+            json={"res": [0]}
         )
 
         # assert no exception is raised
-        self.assertEqual([0],self.inference_client.predict(self.dummy_x))
+        self.assertEqual([0], self.inference_client.predict(self.dummy_x, with_proba=False))
 
     @with_mock_server()
     def test_predict_proba_with_explicit_tabpfn_config(self, mock_server):
         # mock predict_proba response
-        mock_server.router.post(mock_server.endpoints.predict_proba.path).respond(
+        mock_server.router.post(mock_server.endpoints.predict.path).respond(
             200,
-            json={"y_pred_proba": [[0]]}
+            json={"res": [[0]]}
         )
 
         # assert no exception is raised
         tabpfn_config = {"dummy_config": "dummy_value"}
-        self.inference_client.config_tabpfn(**tabpfn_config)
-        self.assertEqual([[0]], self.inference_client.predict_proba(self.dummy_x))
+        self.assertEqual([[0]], self.inference_client.predict(self.dummy_x, tabpfn_config=tabpfn_config))
 
     @with_mock_server()
     def test_predict_proba_with_default_tabpfn_config(self, mock_server):
         # mock predict_proba response
-        mock_server.router.post(mock_server.endpoints.predict_proba.path).respond(
+        mock_server.router.post(mock_server.endpoints.predict.path).respond(
             200,
-            json={"y_pred_proba": [[0]]}
+            json={"res": [[0]]}
         )
 
         # assert no exception is raised
-        self.assertEqual([[0]], self.inference_client.predict_proba(self.dummy_x))
+        self.assertEqual([[0]], self.inference_client.predict(self.dummy_x))


### PR DESCRIPTION
# Development
Allow the user to explicitly specify the TabPFN config for the remote TabPFN.

## Workflow
No changes to how the user interacts with the libraries.
```python
from tabpfn import tabpfn_classifier

tabpfn_classifier.init()

# The following now works for local and remote
tabpfn = tabpfn_classifier.TabPFNClassifier(N_ensemble_configurations=100)
```