### PR TITLE
(CHANGE BASE AND REBASE) Include server error forwarding

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,11 +21,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
       - name: Initialize submodules
         run: git submodule update --init --recursive
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
 
       - name: Run Test
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,6 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+
+**/.DS_Store

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ httpx
 omegaconf
 pandas
 tabpfn
+-r tabpfn_client/tabpfn_common_utils/requirements.txt
 
 # for testing
 respx

--- a/tabpfn_client/remote_tabpfn_classifier.py
+++ b/tabpfn_client/remote_tabpfn_classifier.py
@@ -8,24 +8,24 @@ class RemoteTabPFNClassifier(BaseEstimator, ClassifierMixin):
 
     def __init__(
             self,
-            model=None,
-            device="cpu",
-            base_path=".",
-            model_string="",
-            batch_size_inference=4,
-            fp16_inference=False,
-            inference_mode=True,
-            c=None,
-            N_ensemble_configurations=10,
-            preprocess_transforms=("none", "power_all"),
-            feature_shift_decoder=False,
-            normalize_with_test=False,
-            average_logits=False,
-            categorical_features=tuple(),
-            optimize_metric=None,
-            seed=None,
-            transformer_predict_kwargs_init=None,
-            multiclass_decoder="permutation",
+            # model,
+            device,
+            base_path,
+            model_string,
+            batch_size_inference,
+            # fp16_inference,
+            # inference_mode,
+            # c,
+            N_ensemble_configurations,
+            # preprocess_transforms,
+            feature_shift_decoder,
+            # normalize_with_test,
+            # average_logits,
+            # categorical_features,
+            # optimize_metric,
+            seed,
+            # transformer_predict_kwargs_init,
+            multiclass_decoder,
 
             # dependency injection (for testing)
             inference_handler=InferenceClient()
@@ -35,26 +35,46 @@ class RemoteTabPFNClassifier(BaseEstimator, ClassifierMixin):
         #  In the future version, these configs will be used to create per-user TabPFNClassifier,
         #    allowing the user to setup the desired TabPFNClassifier on the server.
         # config for tabpfn
-        self.model = model
+        # self.model = model
         self.device = device
         self.base_path = base_path
         self.model_string = model_string
         self.batch_size_inference = batch_size_inference
-        self.fp16_inference = fp16_inference
-        self.inference_mode = inference_mode
-        self.c = c
+        # self.fp16_inference = fp16_inference
+        # self.inference_mode = inference_mode
+        # self.c = c
         self.N_ensemble_configurations = N_ensemble_configurations
-        self.preprocess_transforms = preprocess_transforms
+        # self.preprocess_transforms = preprocess_transforms
         self.feature_shift_decoder = feature_shift_decoder
-        self.normalize_with_test = normalize_with_test
-        self.average_logits = average_logits
-        self.categorical_features = categorical_features
-        self.optimize_metric = optimize_metric
+        # self.normalize_with_test = normalize_with_test
+        # self.average_logits = average_logits
+        # self.categorical_features = categorical_features
+        # self.optimize_metric = optimize_metric
         self.seed = seed
-        self.transformer_predict_kwargs_init = transformer_predict_kwargs_init
+        # self.transformer_predict_kwargs_init = transformer_predict_kwargs_init
         self.multiclass_decoder = multiclass_decoder
 
         self.inference_handler = inference_handler
+        self.inference_handler.config_tabpfn(
+            # model=self.model,
+            device=self.device,
+            base_path=str(self.base_path),
+            model_string=self.model_string,
+            batch_size_inference=self.batch_size_inference,
+            # fp16_inference=self.fp16_inference,
+            # inference_mode=self.inference_mode,
+            # c=self.c,
+            N_ensemble_configurations=self.N_ensemble_configurations,
+            # preprocess_transforms=self.preprocess_transforms,
+            feature_shift_decoder=self.feature_shift_decoder,
+            # normalize_with_test=self.normalize_with_test,
+            # average_logits=self.average_logits,
+            # categorical_features=self.categorical_features,
+            # optimize_metric=self.optimize_metric,
+            seed=self.seed,
+            # transformer_predict_kwargs_init=self.transformer_predict_kwargs_init,
+            multiclass_decoder=self.multiclass_decoder,
+        )
 
     def fit(self, X, y):
         self.inference_handler.fit(X, y)

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -1,12 +1,13 @@
-# testing
-protocol: "http"
-host: "0.0.0.0"
-port: "80"
+## testing
+#protocol: "http"
+#host: "0.0.0.0"
+#port: "80"
 
-## production
-#protocol: "https"
-#host: "tabpfn.priorlabs.ai"
-#port: "443"
+# production
+protocol: "https"
+host: "tabpfn.priorlabs.ai"
+port: "443"
+
 endpoints:
   root:
     path: "/"

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -1,12 +1,12 @@
-## testing
-#protocol: "http"
-#host: "0.0.0.0"
-#port: "80"
+# testing
+protocol: "http"
+host: "0.0.0.0"
+port: "80"
 
-# production
-protocol: "https"
-host: "tabpfn.priorlabs.ai"
-port: "443"
+## production
+#protocol: "https"
+#host: "tabpfn.priorlabs.ai"
+#port: "443"
 endpoints:
   root:
     path: "/"

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -1,7 +1,7 @@
 ## testing
 #protocol: "http"
 #host: "0.0.0.0"
-#port: "8000"
+#port: "80"
 
 # production
 protocol: "https"

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -152,13 +152,25 @@ class UserDataClient(ServiceClientWrapper):
 class InferenceClient(ServiceClientWrapper):
     """
     Wrapper of ServiceClient to handle inference, including:
+    - TabPFN model configuration
     - fitting
     - prediction
     """
 
-    def __init__(self, service_client = ServiceClient()):
+    def __init__(self, service_client=ServiceClient()):
         super().__init__(service_client)
         self.last_train_set_uid = None
+        self.tabpfn_config = {}
+
+    def config_tabpfn(self, **kwargs):
+        """
+        Configure TabPFN model.
+
+        If no kwargs is provided, the default config will be used.
+        note: this doesn't check if the keyword nor the value is valid
+        """
+
+        self.tabpfn_config = dict(kwargs)
 
     def fit(self, X, y) -> None:
         if not self.service_client.is_initialized:
@@ -168,14 +180,16 @@ class InferenceClient(ServiceClientWrapper):
 
     def predict(self, X):
         return self.service_client.predict(
+            tabpfn_config=self.tabpfn_config,
             train_set_uid=self.last_train_set_uid,
-            x_test=X
+            x_test=X,
         )
 
     def predict_proba(self, X):
         return self.service_client.predict_proba(
+            tabpfn_config=self.tabpfn_config,
             train_set_uid=self.last_train_set_uid,
-            x_test=X
+            x_test=X,
         )
 
 

--- a/tabpfn_client/tests/unit/test_remote_tabpfn_classifier.py
+++ b/tabpfn_client/tests/unit/test_remote_tabpfn_classifier.py
@@ -25,7 +25,17 @@ class TestRemoteTabPFNClassifier(unittest.TestCase):
         self.mock_client.is_initialized.return_value = True
         inference_handler = InferenceClient(service_client=self.mock_client)
 
-        self.remote_tabpfn = RemoteTabPFNClassifier(inference_handler=inference_handler)
+        self.remote_tabpfn = RemoteTabPFNClassifier(
+            device="cpu",
+            base_path=".",
+            model_string="",
+            batch_size_inference=4,
+            N_ensemble_configurations=4,
+            feature_shift_decoder=False,
+            seed=None,
+            multiclass_decoder="permutation",
+            inference_handler=inference_handler
+        )
 
     def tearDown(self):
         patch.stopall()


### PR DESCRIPTION
## Development
With the development of server ([PR 1](https://github.com/liam-sbhoo/tabpfn-server/pull/23) and [PR 2](https://github.com/liam-sbhoo/tabpfn_common_utils/pull/3))
- **The client can now raise inference-related errors (raised on the server) to the users**

## Question
- Calling `fit` with conflicting X_train and y_train wouldn't raise an error until `predict` is called - calling `fit` would only upload the dataset, but not actually fitting it on TabPFN.
- **Should we change this?**

## Example
The following demonstrates the behavior when the client calls predict with conflicting dataset:
``` python
# Load data
from sklearn.datasets import load_breast_cancer, load_digits
from sklearn.model_selection import train_test_split

breast_X, breast_y = load_breast_cancer(return_X_y=True)
breast_X_train, breast_X_test, breast_y_train, breast_y_test = train_test_split(X, y)
digits_X, digits_y = load_digits(return_X_y=True)
digits_X_train, digits_X_test, digits_y_train, digits_y_test = train_test_split(digits_X, digits_y)

# Init TabPFN
from tabpfn_client import tabpfn_classifier
tabpfn_classifier.init(use_server=True)

# Predict with TabPFN
from tabpfn_client import TabPFNClassifier

tabpfn = TabPFNClassifier()
tabpfn.fit(breast_X_train, breast_y_train)
tabpfn.predict(digits_X_test)
```

Outcome at the client:
<img width="969" alt="image" src="https://github.com/liam-sbhoo/tabpfn_common_utils/assets/44376667/8a9b791e-da4c-48a8-ae40-ec792b341c7a">
