### PR TITLE
Fix:  Test Cases + enable Model Config for TabpfnClassifier after init based on use_server

### DIFF
--- a/quick_test.py
+++ b/quick_test.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
 
     if not use_server:
         tabpfn_classifier.init(use_server=False)
-        tabpfn = TabPFNClassifier(device="cpu", N_ensemble_configurations=4)
+        tabpfn = TabPFNClassifier(device="cpu", N_ensemble_configurations=4, model="tabpfn_1_local")
         # check_estimator(tabpfn)
         tabpfn.fit(np.repeat(X_train,100,axis=0), np.repeat(y_train,100,axis=0))
         print("predicting")
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     else:
         tabpfn_classifier.init()
-        tabpfn = TabPFNClassifier()
+        tabpfn = TabPFNClassifier(model="latest_tabpfn_hosted")
         # print("checking estimator", check_estimator(tabpfn))
         print(X_train.shape[0]*100)
         tabpfn.fit(np.repeat(X_train, 100, axis=0), np.repeat(y_train, 100, axis=0))

--- a/tabpfn_client/tabpfn_classifier.py
+++ b/tabpfn_client/tabpfn_classifier.py
@@ -26,9 +26,9 @@ class TabPFNConfig:
 g_tabpfn_config = TabPFNConfig()
 
 
-# def init(use_server=True):
-def init():
-    use_server = True
+def init(use_server=True):
+    # initialize config
+    use_server = use_server
     global g_tabpfn_config
 
     if use_server:
@@ -76,50 +76,50 @@ def reset():
 
 
 class TabPFNClassifier(BaseEstimator, ClassifierMixin):
-    def __init__(self):
+    # def __init__(self):
         # Configuration for TabPFNClassifier is still under development.
-        pass
-
-    # def __init__(
-    #         self,
-    #         model=None,
-    #         device="cpu",
-    #         base_path=Path(__file__).parent.parent.resolve(),
-    #         model_string="",
-    #         batch_size_inference=4,
-    #         fp16_inference=False,
-    #         inference_mode=True,
-    #         c=None,
-    #         N_ensemble_configurations=10,
-    #         preprocess_transforms=("none", "power_all"),
-    #         feature_shift_decoder=False,
-    #         normalize_with_test=False,
-    #         average_logits=False,
-    #         categorical_features=tuple(),
-    #         optimize_metric=None,
-    #         seed=None,
-    #         transformer_predict_kwargs_init=None,
-    #         multiclass_decoder="permutation",
-    # ):
-    #     # config for tabpfn
-    #     self.model = model
-    #     self.device = device
-    #     self.base_path = base_path
-    #     self.model_string = model_string
-    #     self.batch_size_inference = batch_size_inference
-    #     self.fp16_inference = fp16_inference
-    #     self.inference_mode = inference_mode
-    #     self.c = c
-    #     self.N_ensemble_configurations = N_ensemble_configurations
-    #     self.preprocess_transforms = preprocess_transforms
-    #     self.feature_shift_decoder = feature_shift_decoder
-    #     self.normalize_with_test = normalize_with_test
-    #     self.average_logits = average_logits
-    #     self.categorical_features = categorical_features
-    #     self.optimize_metric = optimize_metric
-    #     self.seed = seed
-    #     self.transformer_predict_kwargs_init = transformer_predict_kwargs_init
-    #     self.multiclass_decoder = multiclass_decoder
+    #     pass
+    
+    def __init__(
+            self,
+            model="latest_tabpfn_hosted",
+            device="cpu",
+            base_path=Path(__file__).parent.parent.resolve(),
+            model_string="",
+            batch_size_inference=4,
+            fp16_inference=False,
+            inference_mode=True,
+            c=None,
+            N_ensemble_configurations=10,
+            preprocess_transforms=("none", "power_all"),
+            feature_shift_decoder=False,
+            normalize_with_test=False,
+            average_logits=False,
+            categorical_features=tuple(),
+            optimize_metric=None,
+            seed=None,
+            transformer_predict_kwargs_init=None,
+            multiclass_decoder="permutation",
+    ):
+        # config for tabpfn
+        self.model = model
+        self.device = device
+        self.base_path = base_path
+        self.model_string = model_string
+        self.batch_size_inference = batch_size_inference
+        self.fp16_inference = fp16_inference
+        self.inference_mode = inference_mode
+        self.c = c
+        self.N_ensemble_configurations = N_ensemble_configurations
+        self.preprocess_transforms = preprocess_transforms
+        self.feature_shift_decoder = feature_shift_decoder
+        self.normalize_with_test = normalize_with_test
+        self.average_logits = average_logits
+        self.categorical_features = categorical_features
+        self.optimize_metric = optimize_metric
+        self.seed = seed
+        self.transformer_predict_kwargs_init = transformer_predict_kwargs_init
+        self.multiclass_decoder = multiclass_decoder
 
     def fit(self, X, y):
         # assert init() is called
@@ -130,34 +130,42 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin):
         if not hasattr(self, "classifier"):
             # arguments that are commented out are not used at the moment
             # (not supported until new TabPFN interface is released)
-            # classifier_cfg = {
-            #     # "model": self.model,
-            #     "device": self.device,
-            #     "base_path": self.base_path,
-            #     "model_string": self.model_string,
-            #     "batch_size_inference": self.batch_size_inference,
-            #     # "fp16_inference": self.fp16_inference,
-            #     # "inference_mode": self.inference_mode,
-            #     # "c": self.c,
-            #     "N_ensemble_configurations": self.N_ensemble_configurations,
-            #     # "preprocess_transforms": self.preprocess_transforms,
-            #     "feature_shift_decoder": self.feature_shift_decoder,
-            #     # "normalize_with_test": self.normalize_with_test,
-            #     # "average_logits": self.average_logits,
-            #     # "categorical_features": self.categorical_features,
-            #     # "optimize_metric": self.optimize_metric,
-            #     "seed": self.seed,
-            #     # "transformer_predict_kwargs_init": self.transformer_predict_kwargs_init,
-            #     "multiclass_decoder": self.multiclass_decoder
-            # }
-            classifier_cfg = {}
+            classifier_cfg = {
+                # "model": self.model,
+                "device": self.device,
+                "base_path": self.base_path,
+                "model_string": self.model_string,
+                "batch_size_inference": self.batch_size_inference,
+                # "fp16_inference": self.fp16_inference,
+                # "inference_mode": self.inference_mode,
+                # "c": self.c,
+                "N_ensemble_configurations": self.N_ensemble_configurations,
+                # "preprocess_transforms": self.preprocess_transforms,
+                "feature_shift_decoder": self.feature_shift_decoder,
+                # "normalize_with_test": self.normalize_with_test,
+                # "average_logits": self.average_logits,
+                # "categorical_features": self.categorical_features,
+                # "optimize_metric": self.optimize_metric,
+                "seed": self.seed,
+                # "transformer_predict_kwargs_init": self.transformer_predict_kwargs_init,
+                "multiclass_decoder": self.multiclass_decoder
+            }
+            #classifier_cfg = {}
 
             if g_tabpfn_config.use_server:
+                try:
+                    assert self.model == "latest_tabpfn_hosted", "Only 'latest_tabpfn_hosted' model is supported at the moment for tabpfn_classifier.init(use_server=True)"
+                except AssertionError as e:
+                    print(e)
                 self.classifier_ = RemoteTabPFNClassifier(
                     **classifier_cfg,
                     inference_handler=g_tabpfn_config.inference_handler
                 )
             else:
+                try:
+                    assert self.model == "tabpfn_1_local", "Only 'tabpfn_1_local' model is supported at the moment for tabpfn_classifier.init(use_server=False)"
+                except AssertionError as e:
+                    print(e)
                 self.classifier_ = LocalTabPFNClassifier(**classifier_cfg)
 
         self.classifier_.fit(X, y)

--- a/tabpfn_client/tests/integration/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/integration/test_tabpfn_classifier.py
@@ -21,7 +21,7 @@ class TestTabPFNClassifier(unittest.TestCase):
 
     def test_use_local_tabpfn_classifier(self):
         tabpfn_classifier.init(use_server=False)
-        tabpfn = TabPFNClassifier(device="cpu")
+        tabpfn = TabPFNClassifier(device="cpu", model="tabpfn_1_local")
         tabpfn.fit(self.X_train, self.y_train)
 
         self.assertTrue(isinstance(tabpfn.classifier_, LocalTabPFNClassifier))

--- a/tabpfn_client/tests/unit/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_classifier.py
@@ -36,7 +36,7 @@ class TestTabPFNClassifierInit(unittest.TestCase):
 
     def test_init_local_classifier(self):
         tabpfn_classifier.init(use_server=False)
-        tabpfn = TabPFNClassifier().fit(self.X_train, self.y_train)
+        tabpfn = TabPFNClassifier(model="tabpfn_1_local").fit(self.X_train, self.y_train)
         self.assertTrue(isinstance(tabpfn.classifier_, LocalTabPFNClassifier))
 
     @with_mock_server()


### PR DESCRIPTION
Issues: init did not had any use_server 
Fix: 2 alternatives : dont pass the variable, or add the argument to the func (I did the latter)

Modifications:
Enable Model Config and add support classifier paramets.