### PR TITLE
Update user registration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ httpx
 omegaconf
 pandas
 tabpfn
+password-strength
 
 # for testing
 respx

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -218,13 +218,43 @@ class ServiceClient:
 
         return is_authenticated
 
+    def validate_email(self, email: str) -> tuple[bool, str]:
+        """
+        Send entered email to server that checks if it is valid and not already in use.
+
+        Parameters
+        ----------
+        email : str
+
+        Returns
+        -------
+        is_valid : bool
+            True if the email is valid.
+        message : str
+            The message returned from the server.
+        """
+        response = self.httpx_client.post(
+            self.server_endpoints.validate_email.path,
+            params={"email": email}
+        )
+
+        self._validate_response(response, "validate_email", only_version_check=True)
+        if response.status_code == 200:
+            is_valid = True
+            message = ""
+        else:
+            is_valid = False
+            message = response.json()["detail"]
+
+        return is_valid, message
+
     def register(
             self,
             email: str,
             password: str,
             password_confirm: str,
             validation_link: str
-    ) -> (bool, str):
+    ) -> tuple[bool, str]:
         """
         Register a new user with the provided credentials.
 
@@ -272,6 +302,8 @@ class ServiceClient:
         -------
         access_token : str | None
             The access token returned from the server. Return None if login fails.
+        message : str
+            The message returned from the server.
         """
 
         access_token = None
@@ -307,6 +339,9 @@ class ServiceClient:
         return response.json()["requirements"]
 
     def add_user_information(self, company: str, role: str, use_case: str, contact_via_email: bool):
+        """
+        Send additional user information to the server.
+        """
         information = {
             "company": company,
             "role": role,

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -338,16 +338,20 @@ class ServiceClient:
 
         return response.json()["requirements"]
 
-    def add_user_information(self, company: str, role: str, use_case: str, contact_via_email: bool):
+    def add_user_information(
+            self, company: str | None, role: str | None, use_case: str | None, contact_via_email: bool
+    ):
         """
         Send additional user information to the server.
         """
-        information = {
-            "company": company,
-            "role": role,
-            "use_case": use_case,
-            "contact_via_email": contact_via_email
-        }
+        information = {"contact_via_email": contact_via_email}
+        if company:
+            information["company"] = company
+        if role:
+            information["role"] = role
+        if use_case:
+            information["use_case"] = use_case
+
         response = self.httpx_client.post(
             self.server_endpoints.add_user_information.path,
             json=information

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -245,7 +245,8 @@ class ServiceClient:
 
         response = self.httpx_client.post(
             self.server_endpoints.register.path,
-            params={"email": email, "password": password, "password_confirm": password_confirm, "validation_link": validation_link}
+            params={"email": email, "password": password, "password_confirm": password_confirm,
+                    "validation_link": validation_link}
         )
 
         self._validate_response(response, "register", only_version_check=True)
@@ -258,7 +259,7 @@ class ServiceClient:
 
         return is_created, message
 
-    def login(self, email: str, password: str) -> str | None:
+    def login(self, email: str, password: str) -> tuple[str, str]:
         """
         Login with the provided credentials and return the access token if successful.
 
@@ -282,8 +283,11 @@ class ServiceClient:
         self._validate_response(response, "login", only_version_check=False)
         if response.status_code == 200:
             access_token = response.json()["access_token"]
+            message = ""
+        else:
+            message = response.json()["detail"]
 
-        return access_token
+        return access_token, message
 
     def get_password_policy(self) -> {}:
         """

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -280,7 +280,7 @@ class ServiceClient:
             data=common_utils.to_oauth_request_form(email, password)
         )
 
-        self._validate_response(response, "login", only_version_check=False)
+        self._validate_response(response, "login", only_version_check=True)
         if response.status_code == 200:
             access_token = response.json()["access_token"]
             message = ""
@@ -318,7 +318,7 @@ class ServiceClient:
             json=information
         )
 
-        self._validate_response(response, "login", only_version_check=True)
+        self._validate_response(response, "add_user_information")
 
     def retrieve_greeting_messages(self) -> list[str]:
         """

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -302,6 +302,20 @@ class ServiceClient:
 
         return response.json()["requirements"]
 
+    def add_user_information(self, company: str, role: str, use_case: str, contact_via_email: bool):
+        information = {
+            "company": company,
+            "role": role,
+            "use_case": use_case,
+            "contact_via_email": contact_via_email
+        }
+        response = self.httpx_client.post(
+            self.server_endpoints.add_user_information.path,
+            json=information
+        )
+
+        self._validate_response(response, "login", only_version_check=True)
+
     def retrieve_greeting_messages(self) -> list[str]:
         """
         Retrieve greeting messages that are new for the user.

--- a/tabpfn_client/prompt_agent.py
+++ b/tabpfn_client/prompt_agent.py
@@ -57,7 +57,7 @@ class PromptAgent:
                 if is_created:
                     break
                 print(cls.indent("User registration failed:" + error_message) + "\n")
-
+            cls.prompt_add_user_information(user_auth_handler)
             print(cls.indent("Account created successfully!") + "\n")
 
         elif choice == "2":
@@ -98,6 +98,29 @@ class PromptAgent:
             raise RuntimeError("Invalid choice")
 
         return choice.lower() == "y"
+
+    @classmethod
+    def prompt_add_user_information(cls, user_auth_handler: "UserAuthenticationClient"):
+        print(cls.indent("To help us tailor our support and services to your needs, we have a few optional questions. "
+                         "Feel free to skip any question by leaving it blank.") + "\n")
+        company = input(cls.indent("Where do you work?: "))
+        role = input(cls.indent("What is your role?: "))
+        use_case = input(cls.indent("What do you want to use TabPFN for?: "))
+
+        contact_via_email = input(cls.indent("Can we reach out to you via email to support you? (y/n):"))
+        is_valid_choice = False
+        for _ in range(3):
+            if contact_via_email.lower() not in ["y", "n"]:
+                contact_via_email = input(cls.indent("Invalid choice, please enter 'y' or 'n': "))
+            else:
+                is_valid_choice = True
+                break
+        if not is_valid_choice or contact_via_email.lower() == "n":
+            contact_via_email = False
+        else:
+            contact_via_email = True
+
+        user_auth_handler.add_user_information(company, role, use_case, contact_via_email)
 
     @classmethod
     def prompt_reusing_existing_token(cls):

--- a/tabpfn_client/prompt_agent.py
+++ b/tabpfn_client/prompt_agent.py
@@ -136,16 +136,14 @@ class PromptAgent:
         choice = input(cls.indent(prompt))
 
         # retry for 3 attempts until valid choice is made
-        is_valid_choice = False
-        for _ in range(max_attempts):
+        for _ in range(max_attempts - 1):
             if choice.lower() not in choices:
                 choices_str = ", ".join(f"'{item}'" for item in choices[:-1]) + f" or '{choices[-1]}'"
                 choice = input(cls.indent(f"Invalid choice, please enter {choices_str}: "))
             else:
-                is_valid_choice = True
                 break
 
-        if not is_valid_choice:
+        if not choice.lower() in choices:
             raise RuntimeError("Invalid choice")
 
         return choice.lower()

--- a/tabpfn_client/prompt_agent.py
+++ b/tabpfn_client/prompt_agent.py
@@ -37,31 +37,39 @@ class PromptAgent:
             #validation_link = input(cls.indent("Please enter your secret code: "))
             validation_link = "tabpfn-2023"
             # create account
-            email = input(cls.indent("Please enter your email: "))
+            while True:
+                email = input(cls.indent("Please enter your email: "))
 
-            password_req = user_auth_handler.get_password_policy()
-            password_req_prompt = "\n".join([
-                "",
-                "Password requirements (minimum):",
-                "\n".join([f". {req}" for req in password_req]),
-                "",
-                "Please enter your password: ",
-            ])
+                password_req = user_auth_handler.get_password_policy()
+                password_req_prompt = "\n".join([
+                    "",
+                    "Password requirements (minimum):",
+                    "\n".join([f". {req}" for req in password_req]),
+                    "",
+                    "Please enter your password: ",
+                ])
 
-            password = getpass.getpass(cls.indent(password_req_prompt))
-            password_confirm = getpass.getpass(cls.indent("Please confirm your password: "))
+                password = getpass.getpass(cls.indent(password_req_prompt))
+                password_confirm = getpass.getpass(cls.indent("Please confirm your password: "))
 
-            user_auth_handler.set_token_by_registration(email, password, password_confirm, validation_link)
+                is_created, error_message = user_auth_handler.set_token_by_registration(
+                    email, password, password_confirm, validation_link)
+                if is_created:
+                    break
+                print(cls.indent("User registration failed:" + error_message) + "\n")
 
             print(cls.indent("Account created successfully!") + "\n")
 
         elif choice == "2":
             # login to account
-            email = input(cls.indent("Please enter your email: "))
-            password = getpass.getpass(cls.indent("Please enter your password: "))
+            while True:
+                email = input(cls.indent("Please enter your email: "))
+                password = getpass.getpass(cls.indent("Please enter your password: "))
 
-            user_auth_handler.set_token_by_login(email, password)
-
+                successful = user_auth_handler.set_token_by_login(email, password)
+                if successful:
+                    break
+                print(cls.indent("Failed to login, please check your email and password.") + "\n")
             print(cls.indent("Login successful!") + "\n")
 
         else:

--- a/tabpfn_client/prompt_agent.py
+++ b/tabpfn_client/prompt_agent.py
@@ -1,5 +1,6 @@
 import textwrap
 import getpass
+from password_strength import PasswordPolicy
 
 
 class PromptAgent:
@@ -8,6 +9,20 @@ class PromptAgent:
         indent_factor = 2
         indent_str = " " * indent_factor
         return textwrap.indent(text, indent_str)
+
+    @staticmethod
+    def password_req_to_policy(password_req: list[str]):
+        """
+        Small function that receives password requirements as a list of
+        strings like "Length(8)" and returns a corresponding
+        PasswordPolicy object.
+        """
+        requirements = {}
+        for req in password_req:
+            word_part, number_part = req.split('(')
+            number = int(number_part[:-1])
+            requirements[word_part.lower()] = number
+        return PasswordPolicy.from_names(**requirements)
 
     @classmethod
     def prompt_welcome(cls):
@@ -35,29 +50,43 @@ class PromptAgent:
 
         # Registration
         if choice == "1":
-            #validation_link = input(cls.indent("Please enter your secret code: "))
+            # validation_link = input(cls.indent("Please enter your secret code: "))
             validation_link = "tabpfn-2023"
-            # create account
             while True:
                 email = input(cls.indent("Please enter your email: "))
-
-                password_req = user_auth_handler.get_password_policy()
-                password_req_prompt = "\n".join([
-                    "",
-                    "Password requirements (minimum):",
-                    "\n".join([f". {req}" for req in password_req]),
-                    "",
-                    "Please enter your password: ",
-                ])
-
-                password = getpass.getpass(cls.indent(password_req_prompt))
-                password_confirm = getpass.getpass(cls.indent("Please confirm your password: "))
-
-                is_created, message = user_auth_handler.set_token_by_registration(
-                    email, password, password_confirm, validation_link)
-                if is_created:
+                # Send request to server to check if email is valid and not already taken.
+                is_valid, message = user_auth_handler.validate_email(email)
+                if is_valid:
                     break
-                print(cls.indent("User registration failed: " + message) + "\n")
+                else:
+                    print(cls.indent(message + "\n"))
+
+            password_req = user_auth_handler.get_password_policy()
+            password_policy = cls.password_req_to_policy(password_req)
+            password_req_prompt = "\n".join([
+                "",
+                "Password requirements (minimum):",
+                "\n".join([f". {req}" for req in password_req]),
+                "",
+                "Please enter your password: ",
+            ])
+            while True:
+                password = getpass.getpass(cls.indent(password_req_prompt))
+                password_req_prompt = "Please enter your password: "
+                if len(password_policy.test(password)) != 0:
+                    print(cls.indent("Password requirements not satisfied.\n"))
+                    continue
+
+                password_confirm = getpass.getpass(cls.indent("Please confirm your password: "))
+                if password == password_confirm:
+                    break
+                else:
+                    print(cls.indent("Entered password and confirmation password do not match, please try again.\n"))
+
+            is_created, message = user_auth_handler.set_token_by_registration(
+                email, password, password_confirm, validation_link)
+            if not is_created:
+                raise RuntimeError("User registration failed: " + message + "\n")
             cls.prompt_add_user_information(user_auth_handler)
             print(cls.indent("Account created successfully!") + "\n")
 
@@ -74,9 +103,6 @@ class PromptAgent:
                 print(cls.indent("Login failed: " + message) + "\n")
             print(cls.indent("Login successful!") + "\n")
 
-        else:
-            raise RuntimeError("Invalid choice")
-
     @classmethod
     def prompt_terms_and_cond(cls) -> bool:
         t_and_c = "\n".join([
@@ -85,15 +111,15 @@ class PromptAgent:
             "Do you agree to the above terms and conditions? (y/n): ",
         ])
         choice = cls._choice_with_retries(t_and_c, ["y", "n"])
-        return choice.lower() == "y"
+        return choice == "y"
 
     @classmethod
     def prompt_add_user_information(cls, user_auth_handler: "UserAuthenticationClient"):
         print(cls.indent("To help us tailor our support and services to your needs, we have a few optional questions. "
                          "Feel free to skip any question by leaving it blank.") + "\n")
-        company = input(cls.indent("Where do you work?: "))
-        role = input(cls.indent("What is your role?: "))
-        use_case = input(cls.indent("What do you want to use TabPFN for?: "))
+        company = input(cls.indent("Where do you work? "))
+        role = input(cls.indent("What is your role? "))
+        use_case = input(cls.indent("What do you want to use TabPFN for? "))
 
         choice_contact = cls._choice_with_retries(
             "Can we reach out to you via email to support you? (y/n):", ["y", "n"]
@@ -128,22 +154,20 @@ class PromptAgent:
         print(cls.indent("Your account has been deleted."))
 
     @classmethod
-    def _choice_with_retries(cls, prompt: str, choices: list, max_attempts: int = 3) -> str:
+    def _choice_with_retries(cls, prompt: str, choices: list) -> str:
         """
-        Prompt text and give user predefined number of attempts to select one of the possible choices. If valid choice
-        is selected, return choice in lowercase, otherwise raise RuntimeError.
+        Prompt text and give user infinitely many attempts to select one of the possible choices. If valid choice
+        is selected, return choice in lowercase.
         """
+        assert all(c.lower() == c for c in choices), "Choices need to be lower case."
         choice = input(cls.indent(prompt))
 
-        # retry for 3 attempts until valid choice is made
-        for _ in range(max_attempts - 1):
+        # retry until valid choice is made
+        while True:
             if choice.lower() not in choices:
                 choices_str = ", ".join(f"'{item}'" for item in choices[:-1]) + f" or '{choices[-1]}'"
                 choice = input(cls.indent(f"Invalid choice, please enter {choices_str}: "))
             else:
                 break
-
-        if not choice.lower() in choices:
-            raise RuntimeError("Invalid choice")
 
         return choice.lower()

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -33,6 +33,11 @@ endpoints:
     methods: [ "GET" ]
     description: "Retrieve new greeting messages"
 
+  add_user_information:
+    path: "/add_user_information"
+    methods: [ "POST" ]
+    description: "Add additional user information to database"
+
   protected_root:
     path: "/protected/"
     methods: [ "GET" ]

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -18,6 +18,11 @@ endpoints:
     methods: [ "GET" ]
     description: "Password policy"
 
+  validate_email:
+    path: "/auth/validate_email/"
+    methods: [ "POST" ]
+    description: "Validate email"
+
   register:
     path: "/auth/register/"
     methods: [ "POST" ]

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -34,7 +34,7 @@ endpoints:
     description: "Retrieve new greeting messages"
 
   add_user_information:
-    path: "/add_user_information"
+    path: "/add_user_information/"
     methods: [ "POST" ]
     description: "Add additional user information to database"
 

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -30,6 +30,10 @@ class UserAuthenticationClient(ServiceClientWrapper):
         self.CACHED_TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
         self.CACHED_TOKEN_FILE.write_text(access_token)
 
+    def validate_email(self, email: str) -> tuple[bool, str]:
+        is_valid, message = self.service_client.validate_email(email)
+        return is_valid, message
+
     def set_token_by_registration(
             self,
             email: str,

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -37,8 +37,6 @@ class UserAuthenticationClient(ServiceClientWrapper):
             password_confirm: str,
             validation_link: str
     ) -> tuple[bool, str]:
-        if password != password_confirm:
-            raise ValueError("Password and password_confirm must be the same.")
 
         is_created, message = self.service_client.register(email, password, password_confirm, validation_link)
         if is_created:

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -78,6 +78,9 @@ class UserAuthenticationClient(ServiceClientWrapper):
     def get_password_policy(self):
         return self.service_client.get_password_policy()
 
+    def add_user_information(self, company: str, role: str, use_case: str, contact_via_email: bool):
+        self.service_client.add_user_information(company, role, use_case, contact_via_email)
+
     def reset_cache(self):
         self._reset_token()
 

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -46,14 +46,14 @@ class UserAuthenticationClient(ServiceClientWrapper):
             self.set_token_by_login(email, password)
         return is_created, message
 
-    def set_token_by_login(self, email: str, password: str) -> bool:
-        access_token = self.service_client.login(email, password)
+    def set_token_by_login(self, email: str, password: str) -> tuple[bool, str]:
+        access_token, message = self.service_client.login(email, password)
 
         if access_token is None:
-            raise False
+            return False, message
 
         self.set_token(access_token)
-        return True
+        return True, message
 
     def try_reuse_existing_token(self) -> bool:
         if self.service_client.access_token is None:

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -80,7 +80,9 @@ class UserAuthenticationClient(ServiceClientWrapper):
     def get_password_policy(self):
         return self.service_client.get_password_policy()
 
-    def add_user_information(self, company: str, role: str, use_case: str, contact_via_email: bool):
+    def add_user_information(
+            self, company: str | None, role: str | None, use_case: str | None, contact_via_email: bool
+    ):
         self.service_client.add_user_information(company, role, use_case, contact_via_email)
 
     def reset_cache(self):

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -37,6 +37,17 @@ class TestServiceClient(unittest.TestCase):
         self.assertTrue(str(cm.exception).startswith("Client version too old."))
 
     @with_mock_server()
+    def test_validate_email(self, mock_server):
+        mock_server.router.post(mock_server.endpoints.validate_email.path).respond(200, json={"message": "dummy_message"})
+        self.assertTrue(self.client.validate_email("dummy_email")[0])
+
+    @with_mock_server()
+    def test_validate_email_invalid(self, mock_server):
+        mock_server.router.post(mock_server.endpoints.validate_email.path).respond(401, json={"detail": "dummy_message"})
+        self.assertFalse(self.client.validate_email("dummy_email")[0])
+        self.assertEqual("dummy_message", self.client.validate_email("dummy_email")[1])
+
+    @with_mock_server()
     def test_register_user(self, mock_server):
         mock_server.router.post(mock_server.endpoints.register.path).respond(200, json={"message": "dummy_message"})
         self.assertTrue(self.client.register("dummy_email", "dummy_password", "dummy_password", "dummy_validation")[0])

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -90,6 +90,15 @@ class TestServiceClient(unittest.TestCase):
         )
         self.assertTrue(np.array_equal(pred, dummy_result["y_pred"]))
 
+    @with_mock_server()
+    def test_add_user_information(self, mock_server):
+        mock_server.router.post(mock_server.endpoints.add_user_information.path).respond(200)
+        self.assertIsNone(self.client.add_user_information(
+            "company", "dev", "", True))
+        mock_server.router.post(mock_server.endpoints.add_user_information.path).respond(500)
+        self.assertIsNone(self.client.add_user_information(
+            "company", "dev", "", True))
+
     def test_validate_response_no_error(self):
         response = Mock()
         response.status_code = 200

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -95,9 +95,12 @@ class TestServiceClient(unittest.TestCase):
         mock_server.router.post(mock_server.endpoints.add_user_information.path).respond(200)
         self.assertIsNone(self.client.add_user_information(
             "company", "dev", "", True))
+
+    @with_mock_server()
+    def test_add_user_information_raises_runtime_error(self, mock_server):
         mock_server.router.post(mock_server.endpoints.add_user_information.path).respond(500)
-        self.assertIsNone(self.client.add_user_information(
-            "company", "dev", "", True))
+        with self.assertRaises(RuntimeError):
+            self.client.add_user_information("company", "dev", "", True)
 
     def test_validate_response_no_error(self):
         response = Mock()

--- a/tabpfn_client/tests/unit/test_prompt_agent.py
+++ b/tabpfn_client/tests/unit/test_prompt_agent.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import respx
+from httpx import Response
+from tabpfn_client.prompt_agent import PromptAgent
+from tabpfn_client.tests.mock_tabpfn_server import with_mock_server
+from tabpfn_client.service_wrapper import UserAuthenticationClient, ServiceClient
+
+
+class TestPromptAgent(unittest.TestCase):
+    @with_mock_server()
+    @patch('getpass.getpass', side_effect=['password123', 'password123'])
+    @patch('builtins.input', side_effect=['1', 'user@example.com', 'test', 'test', 'test', 'y'])
+    def test_prompt_and_set_token_registration(self, mock_input, mock_getpass, mock_server):
+        mock_auth_client = MagicMock()
+        mock_auth_client.get_password_policy.return_value = ['At least 8 characters']
+        mock_auth_client.set_token_by_registration.return_value = (True, 'Registration successful')
+        PromptAgent.prompt_and_set_token(user_auth_handler=mock_auth_client)
+        mock_auth_client.set_token_by_registration.assert_called_once()
+
+    @patch('getpass.getpass', side_effect = ['password123'])
+    @patch('builtins.input', side_effect=['2', 'user@example.com'])
+    def test_prompt_and_set_token_login(self, mock_input, mock_getpass):
+        mock_auth_client = MagicMock()
+        mock_auth_client.set_token_by_login.return_value = (True, 'Login successful')
+        PromptAgent.prompt_and_set_token(user_auth_handler=mock_auth_client)
+        mock_auth_client.set_token_by_login.assert_called_once()
+
+    @patch('builtins.input', return_value='y')
+    def test_prompt_terms_and_cond_returns_true(self, mock_input):
+        result = PromptAgent.prompt_terms_and_cond()
+        self.assertTrue(result)
+
+    @patch('builtins.input', return_value='n')
+    def test_prompt_terms_and_cond_returns_false(self, mock_input):
+        result = PromptAgent.prompt_terms_and_cond()
+        self.assertFalse(result)
+
+    @patch('builtins.input', return_value='1')
+    def test_choice_with_retries_valid_first_try(self, mock_input):
+        result = PromptAgent._choice_with_retries("Please enter your choice: ", ["1", "2"])
+        self.assertEqual(result, '1')
+
+    @patch('builtins.input', side_effect=['3', '3', '1'])
+    def test_choice_with_retries_valid_last_try(self, mock_input):
+        result = PromptAgent._choice_with_retries("Please enter your choice: ", ["1", "2"], max_attempts=3)
+        self.assertEqual(result, '1')
+
+    # Test handling all inputs invalid within the allowed attempts
+    @patch('builtins.input', side_effect=['3', '4', '5'])
+    def test_choice_with_retries_raises_runtime_error(self, mock_input):
+        with self.assertRaises(RuntimeError):
+            PromptAgent._choice_with_retries("Please enter your choice: ", ["1", "2"], max_attempts=3)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tabpfn_client/tests/unit/test_prompt_agent.py
+++ b/tabpfn_client/tests/unit/test_prompt_agent.py
@@ -8,13 +8,20 @@ from tabpfn_client.service_wrapper import UserAuthenticationClient, ServiceClien
 
 
 class TestPromptAgent(unittest.TestCase):
+    def test_password_req_to_policy(self):
+        password_req = ["Length(8)", "Uppercase(1)", "Numbers(1)", "Special(1)"]
+        password_policy = PromptAgent.password_req_to_policy(password_req)
+        requirements = [repr(req) for req in password_policy.test("")]
+        self.assertEqual(password_req, requirements)
+
     @with_mock_server()
-    @patch('getpass.getpass', side_effect=['password123', 'password123'])
+    @patch('getpass.getpass', side_effect=['Password123!', 'Password123!'])
     @patch('builtins.input', side_effect=['1', 'user@example.com', 'test', 'test', 'test', 'y'])
     def test_prompt_and_set_token_registration(self, mock_input, mock_getpass, mock_server):
         mock_auth_client = MagicMock()
-        mock_auth_client.get_password_policy.return_value = ['At least 8 characters']
+        mock_auth_client.get_password_policy.return_value = ['Length(8)', 'Uppercase(1)', 'Numbers(1)', 'Special(1)']
         mock_auth_client.set_token_by_registration.return_value = (True, 'Registration successful')
+        mock_auth_client.validate_email.return_value = (True, '')
         PromptAgent.prompt_and_set_token(user_auth_handler=mock_auth_client)
         mock_auth_client.set_token_by_registration.assert_called_once()
 
@@ -42,11 +49,6 @@ class TestPromptAgent(unittest.TestCase):
         self.assertEqual(result, '1')
 
     @patch('builtins.input', side_effect=['3', '3', '1'])
-    def test_choice_with_retries_valid_last_try(self, mock_input):
-        result = PromptAgent._choice_with_retries("Please enter your choice: ", ["1", "2"], max_attempts=3)
+    def test_choice_with_retries_valid_third_try(self, mock_input):
+        result = PromptAgent._choice_with_retries("Please enter your choice: ", ["1", "2"])
         self.assertEqual(result, '1')
-
-    @patch('builtins.input', side_effect=['3', '4', '5'])
-    def test_choice_with_retries_raises_runtime_error(self, mock_input):
-        with self.assertRaises(RuntimeError):
-            PromptAgent._choice_with_retries("Please enter your choice: ", ["1", "2"], max_attempts=3)

--- a/tabpfn_client/tests/unit/test_prompt_agent.py
+++ b/tabpfn_client/tests/unit/test_prompt_agent.py
@@ -46,12 +46,7 @@ class TestPromptAgent(unittest.TestCase):
         result = PromptAgent._choice_with_retries("Please enter your choice: ", ["1", "2"], max_attempts=3)
         self.assertEqual(result, '1')
 
-    # Test handling all inputs invalid within the allowed attempts
     @patch('builtins.input', side_effect=['3', '4', '5'])
     def test_choice_with_retries_raises_runtime_error(self, mock_input):
         with self.assertRaises(RuntimeError):
             PromptAgent._choice_with_retries("Please enter your choice: ", ["1", "2"], max_attempts=3)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tabpfn_client/tests/unit/test_service_wrapper.py
+++ b/tabpfn_client/tests/unit/test_service_wrapper.py
@@ -38,13 +38,11 @@ class TestUserAuthClient(unittest.TestCase):
     @with_mock_server()
     def test_set_token_by_invalid_login(self, mock_server):
         # mock invalid login response
-        mock_server.router.post(mock_server.endpoints.login.path).respond(400)
-
-        # assert exception is raised
-        self.assertRaises(
-            RuntimeError,
-            UserAuthenticationClient(ServiceClient()).set_token_by_login,
-            "dummy_email", "dummy_password"
+        mock_server.router.post(mock_server.endpoints.login.path).respond(401, json={
+            "detail": "Incorrect email or password"})
+        self.assertEqual(
+            (False, "Incorrect email or password"),
+            UserAuthenticationClient(ServiceClient()).set_token_by_login("dummy_email", "dummy_password")
         )
 
         # assert token is not set
@@ -98,16 +96,13 @@ class TestUserAuthClient(unittest.TestCase):
     @with_mock_server()
     def test_set_token_by_invalid_registration(self, mock_server):
         # mock invalid registration response
-        mock_server.router.post(mock_server.endpoints.register.path).respond(
-            400,
-            json={"detail": "doesn't matter"}
-        )
-
-        # assert exception is raised
-        self.assertRaises(
-            RuntimeError,
-            UserAuthenticationClient(ServiceClient()).set_token_by_registration,
-            "dummy_email", "dummy_password", "dummy_password", "dummy_validation"
+        mock_server.router.post(mock_server.endpoints.register.path).respond(401, json={
+            "detail": "Password mismatch"})
+        self.assertEqual(
+            (False, "Password mismatch"),
+            UserAuthenticationClient(ServiceClient()).set_token_by_registration(
+                "dummy_email", "dummy_password", "dummy_password",
+                "dummy_validation")
         )
 
         # assert token is not set

--- a/tabpfn_client/tests/unit/test_service_wrapper.py
+++ b/tabpfn_client/tests/unit/test_service_wrapper.py
@@ -29,8 +29,8 @@ class TestUserAuthClient(unittest.TestCase):
             json={"access_token": dummy_token}
         )
 
-        # assert no exception is raised
-        UserAuthenticationClient(ServiceClient()).set_token_by_login("dummy_email", "dummy_password")
+        self.assertTrue(UserAuthenticationClient(ServiceClient()).set_token_by_login(
+            "dummy_email", "dummy_password")[0])
 
         # assert token is set
         self.assertEqual(dummy_token, ServiceClient().access_token)
@@ -85,9 +85,10 @@ class TestUserAuthClient(unittest.TestCase):
             json={"access_token": dummy_token}
         )
 
-        # assert no exception is raised
-        UserAuthenticationClient(ServiceClient()).set_token_by_registration(
-            "dummy_email", "dummy_password", "dummy_password", "dummy_validation"
+        self.assertTrue(
+            UserAuthenticationClient(ServiceClient()).set_token_by_registration(
+                "dummy_email", "dummy_password", "dummy_password", "dummy_validation"
+            )[0]
         )
 
         # assert token is set


### PR DESCRIPTION
This PR introduces the following things:
- Simplify registration/login process by allowing retries
- Ask users some additional questions during registration.

## Allowing retries
Update registration and login functions such that they return if the login/registration was successfull and the response of the server. If the attempt was not successfull, print the response of the server (e.g. 'Weak Password') and restart the registration/login process.

## Asking additional questions
After the registration process that we had before is finished, ask the user a few more questions, which are optional. We can fine-tune the exact wording. The information entered is then sent to the server in a second request. The user is already added to the database after the first request (which we already had before). I thought this was simplest way to do it, if we send everything in one request, all the answers to the questions will have to be entered again if there was a problem at the beginning, e.g. with the password.

If you have further ideas/thoughts on this please let me know :)