### PR TITLE
Store last train set uid in classifier/regressor class

### DIFF
--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -181,6 +181,7 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin):
         self.remove_outliers = remove_outliers
         self.add_fingerprint_features = add_fingerprint_features
         self.subsample_samples = subsample_samples
+        self.last_train_set_uid = None
 
     def _validate_targets_and_classes(self, y) -> np.ndarray:
         from sklearn.utils import column_or_1d
@@ -206,7 +207,7 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin):
                 ), "Only 'latest_tabpfn_hosted' model is supported at the moment for init(use_server=True)"
             except AssertionError as e:
                 print(e)
-            config.g_tabpfn_config.inference_handler.fit(X, y)
+            self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
             self.fitted_ = True
         else:
             raise NotImplementedError(
@@ -223,7 +224,10 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin):
     def predict_proba(self, X):
         check_is_fitted(self)
         return config.g_tabpfn_config.inference_handler.predict(
-            X, task="classification", config=self.get_params()
+            X,
+            task="classification",
+            train_set_uid=self.last_train_set_uid,
+            config=self.get_params(),
         )["probas"]
 
 
@@ -323,6 +327,7 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin):
         self.cancel_nan_borders = cancel_nan_borders
         self.super_bar_dist_averaging = super_bar_dist_averaging
         self.subsample_samples = subsample_samples
+        self.last_train_set_uid = None
 
     def fit(self, X, y):
         # assert init() is called
@@ -335,7 +340,7 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin):
                 ), "Only 'latest_tabpfn_hosted' model is supported at the moment for init(use_server=True)"
             except AssertionError as e:
                 print(e)
-            config.g_tabpfn_config.inference_handler.fit(X, y)
+            self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
             self.fitted_ = True
         else:
             raise NotImplementedError(
@@ -357,5 +362,8 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin):
     def predict_full(self, X):
         check_is_fitted(self)
         return config.g_tabpfn_config.inference_handler.predict(
-            X, task="regression", config=self.get_params()
+            X,
+            task="regression",
+            train_set_uid=self.last_train_set_uid,
+            config=self.get_params(),
         )

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -178,20 +178,25 @@ class InferenceClient(ServiceClientWrapper):
 
     def __init__(self, service_client=ServiceClient()):
         super().__init__(service_client)
-        self.last_train_set_uid = None
 
-    def fit(self, X, y) -> None:
+    def fit(self, X, y) -> str:
         if not self.service_client.is_initialized:
             raise RuntimeError(
                 "Dear TabPFN User, please initialize the client first by verifying your E-mail address sent to your registered E-mail account."
                 "Please Note: The email verification token expires in 30 minutes."
             )
 
-        self.last_train_set_uid = self.service_client.upload_train_set(X, y)
+        return self.service_client.upload_train_set(X, y)
 
-    def predict(self, X, task: Literal["classification", "regression"], config=None):
+    def predict(
+        self,
+        X,
+        task: Literal["classification", "regression"],
+        train_set_uid: str,
+        config=None,
+    ):
         return self.service_client.predict(
-            train_set_uid=self.last_train_set_uid,
+            train_set_uid=train_set_uid,
             x_test=X,
             tabpfn_config=config,
             task=task,


### PR DESCRIPTION
### Change Description

*Try to be precise. You can additionally add comments to your PR, this might help the reviewer a lot.*

Currently we have the following incorrect behavior:
model1.fit(X1,Y1)
model2.fit(X2,Y2)
model1.predict will now use X2, Y2 instead of X1, Y1

This PR fixes this problem by storing the last_train_set_uid in the Classifier/Regressor class instead of the InferenceClient class. This allows each classifier/regressor instance to keep track of the corresponding last train set it was fitted on.

**If you used new dependencies: Did you add them to `requirements.txt`?**
-
**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**
@SamuelGabriel 

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**
No
**Does this PR break the user interface? If so, why?**
No
---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
