### PR TITLE
Remove outdated assertion on model support

### DIFF
--- a/tabpfn_client/config.py
+++ b/tabpfn_client/config.py
@@ -7,8 +7,8 @@ from tabpfn_client.prompt_agent import PromptAgent
 
 
 class TabPFNConfig:
-    is_initialized = None
-    use_server = None
+    is_initialized = False
+    use_server = False
     user_auth_handler = None
     inference_handler = None
 

--- a/tabpfn_client/config.py
+++ b/tabpfn_client/config.py
@@ -25,7 +25,7 @@ def init(use_server=True):
         # Only do the following if the initialization has not been done yet
         return
 
-    if use_server:   
+    if use_server:
         service_client = ServiceClient()
         user_auth_handler = UserAuthenticationClient(service_client)
 

--- a/tabpfn_client/config.py
+++ b/tabpfn_client/config.py
@@ -21,7 +21,11 @@ def init(use_server=True):
     use_server = use_server
     global g_tabpfn_config
 
-    if use_server:
+    if g_tabpfn_config.is_initialized:
+        # Only do the following if the initialization has not been done yet
+        return
+
+    if use_server:   
         service_client = ServiceClient()
         user_auth_handler = UserAuthenticationClient(service_client)
 
@@ -60,7 +64,8 @@ def init(use_server=True):
         g_tabpfn_config.inference_handler = InferenceClient(service_client)
 
     else:
-        g_tabpfn_config.use_server = False
+        raise RuntimeError("Local inference is not supported yet.")
+        # g_tabpfn_config.use_server = False
 
     g_tabpfn_config.is_initialized = True
 

--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -232,9 +232,18 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin):
 
 
 class TabPFNRegressor(BaseEstimator, RegressorMixin):
+
+    _AVAILABLE_MODELS = [
+        "default",
+        "2noar4o2",
+        "5wof9ojf",
+        "09gpqh39",
+        "wyl4o83o",
+    ]
+
     def __init__(
         self,
-        model: str = "latest_tabpfn_hosted",
+        model_path: str = "default",
         n_estimators: int = 8,
         preprocess_transforms: Tuple[PreprocessorConfig, ...] = (
             PreprocessorConfig(
@@ -310,7 +319,7 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin):
                 If in 0 to 1, the value is viewed as a fraction of the training set size.
         """
 
-        self.model = model
+        self.model_path = self._model_name_to_path(model_path)
         self.n_estimators = n_estimators
         self.preprocess_transforms = preprocess_transforms
         self.feature_shift_decoder = feature_shift_decoder
@@ -361,3 +370,16 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin):
             train_set_uid=self.last_train_set_uid,
             config=self.get_params(),
         )
+    
+    @classmethod
+    def list_available_models(cls) -> list[str]:
+        return cls._AVAILABLE_MODELS
+
+    def _model_name_to_path(self, model_name: str) -> str:
+        base_path = "/home/venv/lib/python3.9/site-packages/tabpfn/model_cache/model_hans_regression"
+        if model_name == "default":
+            return f"{base_path}.ckpt"
+        elif model_name in self._AVAILABLE_MODELS:
+            return f"{base_path}_{model_name}.ckpt"
+        else:
+            raise ValueError(f"Invalid model name: {model_name}")

--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -232,7 +232,6 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin):
 
 
 class TabPFNRegressor(BaseEstimator, RegressorMixin):
-
     _AVAILABLE_MODELS = [
         "default",
         "2noar4o2",
@@ -370,7 +369,7 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin):
             train_set_uid=self.last_train_set_uid,
             config=self.get_params(),
         )
-    
+
     @classmethod
     def list_available_models(cls) -> list[str]:
         return cls._AVAILABLE_MODELS

--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -334,12 +334,6 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin):
         init()
 
         if config.g_tabpfn_config.use_server:
-            try:
-                assert (
-                    self.model == "latest_tabpfn_hosted"
-                ), "Only 'latest_tabpfn_hosted' model is supported at the moment for init(use_server=True)"
-            except AssertionError as e:
-                print(e)
             self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
             self.fitted_ = True
         else:

--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -368,9 +368,11 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin):
         check_is_fitted(self)
 
         estimator_param = self.get_params()
-        if 'model' in estimator_param:
+        if "model" in estimator_param:
             # replace model by model_path since in TabPFN defines model as model_path
-            estimator_param["model_path"] = self._model_name_to_path(estimator_param.pop('model'))
+            estimator_param["model_path"] = self._model_name_to_path(
+                estimator_param.pop("model")
+            )
 
         return config.g_tabpfn_config.inference_handler.predict(
             X,

--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -242,7 +242,7 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin):
 
     def __init__(
         self,
-        model_path: str = "default",
+        model: str = "default",
         n_estimators: int = 8,
         preprocess_transforms: Tuple[PreprocessorConfig, ...] = (
             PreprocessorConfig(
@@ -318,7 +318,7 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin):
                 If in 0 to 1, the value is viewed as a fraction of the training set size.
         """
 
-        self.model_path = self._model_name_to_path(model_path)
+        self.model_path = self._model_name_to_path(model)
         self.n_estimators = n_estimators
         self.preprocess_transforms = preprocess_transforms
         self.feature_shift_decoder = feature_shift_decoder

--- a/tabpfn_client/tests/unit/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_classifier.py
@@ -58,10 +58,6 @@ class TestTabPFNClassifierInit(unittest.TestCase):
             mock_server.endpoints.retrieve_greeting_messages.path
         ).respond(200, json={"messages": []})
 
-        mock_server.router.get(mock_server.endpoints.protected_root.path).respond(
-            200, json={"message": "Welcome to the protected zone, user!"}
-        )
-
         mock_predict_response = [[1, 0.0], [0.9, 0.1], [0.01, 0.99]]
         predict_route = mock_server.router.post(mock_server.endpoints.predict.path)
         predict_route.respond(200, json={"classification": mock_predict_response})

--- a/tabpfn_client/tests/unit/test_tabpfn_regressor.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_regressor.py
@@ -83,6 +83,17 @@ class TestTabPFNRegressorInit(unittest.TestCase):
             "check that n_estimators is passed to the server",
         )
 
+    def test_valid_model_config(self):
+        # Test with valid model configuration
+        model_name = TabPFNRegressor.list_available_models()[0]
+        valid_config = TabPFNRegressor(model=model_name)
+        self.assertEqual(valid_config.model, model_name)
+
+    def test_invalid_model_config(self):
+        # Test with invalid model configuration
+        with self.assertRaises(ValueError):
+            TabPFNRegressor(model="invalid_model_name")
+
     @with_mock_server()
     def test_reuse_saved_access_token(self, mock_server):
         # mock connection and authentication

--- a/tabpfn_client/tests/unit/test_tabpfn_regressor.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_regressor.py
@@ -56,10 +56,6 @@ class TestTabPFNRegressorInit(unittest.TestCase):
             mock_server.endpoints.retrieve_greeting_messages.path
         ).respond(200, json={"messages": []})
 
-        mock_server.router.get(mock_server.endpoints.protected_root.path).respond(
-            200, json={"message": "Welcome to the protected zone, user!"}
-        )
-
         mock_predict_response = {
             "mean": [100, 200, 300],
             "median": [110, 210, 310],


### PR DESCRIPTION
### Change Description

I think this assertion is outdated.

**Addition / Fix:**
- `TabPFNRegressor.list_available_models()`
- add model support
- fix unnecessary welcoming message everytime we call fit.

**I have tested it (checked from Vertex log, make sure the model specified in client is being used).**

*Try to be precise. You can additionally add comments to your PR, this might help the reviewer a lot.*


**If you used new dependencies: Did you add them to `requirements.txt`?**

NO

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**

**Does this PR break the user interface? If so, why?**

---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
