### PR TITLE
Setter of Access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ pip install tabpfn-client
 Import and login
 ```python
 from tabpfn_client import init, TabPFNClassifier
-init()
+
+- To create a new account, simply call the init() or complete the registration process during tabpfn.fit(). 
+
+- Once registered, you will get the information about where your access token is stored, which you can also get by get_token() if it exists.
+
+- Have a valid access token? Directly login using:
+init(access_token="valid_access_token")
+
 ```
 
 Now you can use our model just like any other sklearn estimator
@@ -44,18 +51,14 @@ To login using your access token, skipping the interactive flow, use:
 from tabpfn_client import config
 
 # Retrieve Token
-with open(config.g_tabpfn_config.user_auth_handler.CACHED_TOKEN_FILE, 'r') as file:
-    token = file.read()
-print(f"TOKEN: {token}")
+get_token()
 ```
 
 ```python
 from tabpfn_client import config
 
 # Set Token
-service_client = config.ServiceClient()
-config.g_tabpfn_config.user_auth_handler = config.UserAuthenticationClient(service_client=service_client)
-user_auth = config.g_tabpfn_config.user_auth_handler.set_token(token)
+init(access_token="valid_access_token")
 ```
 
 # Development

--- a/tabpfn_client/__init__.py
+++ b/tabpfn_client/__init__.py
@@ -1,5 +1,12 @@
-from tabpfn_client.config import init, reset
+from tabpfn_client.config import init, reset, get_token
 from tabpfn_client.estimator import TabPFNClassifier, TabPFNRegressor
 from tabpfn_client.service_wrapper import UserDataClient
 
-__all__ = ["init", "reset", "TabPFNClassifier", "TabPFNRegressor", "UserDataClient"]
+__all__ = [
+    "init",
+    "reset",
+    "get_token",
+    "TabPFNClassifier",
+    "TabPFNRegressor",
+    "UserDataClient",
+]

--- a/tabpfn_client/config.py
+++ b/tabpfn_client/config.py
@@ -4,6 +4,7 @@ from tabpfn_client.service_wrapper import UserAuthenticationClient, InferenceCli
 from tabpfn_client.client import ServiceClient
 from tabpfn_client.constants import CACHE_DIR
 from tabpfn_client.prompt_agent import PromptAgent
+from tabpfn_client import constants
 
 
 class TabPFNConfig:
@@ -16,7 +17,7 @@ class TabPFNConfig:
 g_tabpfn_config = TabPFNConfig()
 
 
-def init(use_server=True):
+def init(use_server=True, access_token=None):
     # initialize config
     use_server = use_server
     global g_tabpfn_config
@@ -34,6 +35,9 @@ def init(use_server=True):
             raise RuntimeError(
                 "TabPFN is inaccessible at the moment, please try again later."
             )
+
+        if access_token is not None:
+            user_auth_handler.set_token(access_token)
 
         is_valid_token_set = user_auth_handler.try_reuse_existing_token()
 
@@ -81,3 +85,16 @@ def reset():
 
     # remove cache dir
     shutil.rmtree(CACHE_DIR, ignore_errors=True)
+
+
+def get_token():
+    if constants.CACHE_DIR.exists():
+        with open(constants.CACHE_DIR / "config", "r") as file:
+            token = file.read()
+            print(f"Access Token on Disk: {token}\n")
+    else:
+        print(
+            "No access token found on disk. Please set your access token using the `init` function."
+        )
+
+    PromptAgent.prompt_access_token_information()

--- a/tabpfn_client/config.py
+++ b/tabpfn_client/config.py
@@ -48,6 +48,7 @@ def init(use_server=True, access_token=None):
         ):
             print("Your email is not verified. Please verify your email to continue...")
             PromptAgent.reverify_email(is_valid_token_set[1], user_auth_handler)
+            user_auth_handler.set_token(is_valid_token_set[1])
         else:
             PromptAgent.prompt_welcome()
             if not PromptAgent.prompt_terms_and_cond():
@@ -77,12 +78,12 @@ def init(use_server=True, access_token=None):
 def reset():
     # reset config
     global g_tabpfn_config
-    g_tabpfn_config = TabPFNConfig()
-
     # reset user auth handler
-    if g_tabpfn_config.use_server:
+    if g_tabpfn_config.use_server and g_tabpfn_config.user_auth_handler is not None:
         g_tabpfn_config.user_auth_handler.reset_cache()
 
+    # reset config
+    g_tabpfn_config = TabPFNConfig()
     # remove cache dir
     shutil.rmtree(CACHE_DIR, ignore_errors=True)
 

--- a/tabpfn_client/prompt_agent.py
+++ b/tabpfn_client/prompt_agent.py
@@ -28,6 +28,26 @@ class PromptAgent:
             requirements[word_part.lower()] = number
         return PasswordPolicy.from_names(**requirements)
 
+    @staticmethod
+    def prompt_access_token_information():
+        """
+        Print information about the access token.
+        Where to find it, how to use it, how to reset it etc.
+        """
+        prompt = "\n".join(
+            [
+                "Please Note:\n",
+                "- Your access token is a secret key that allows you to use TabPFN-Client services.",
+                "- You can find your access token in the 'config' file under the './tabpfn' directory.",
+                "- The access token expires one year after your initial login.",
+                "- If you lose your access token, you can reset it using the `reset()` function and log in again.",
+                "- Keep it safe, and do not share it with anyone.",
+                "",
+            ]
+        )
+
+        print(PromptAgent.indent(prompt))
+
     @classmethod
     def prompt_welcome(cls):
         prompt = "\n".join(
@@ -112,6 +132,7 @@ class PromptAgent:
                 )
                 + "\n"
             )
+            cls.prompt_access_token_information()
 
         # Login
         elif choice == "2":

--- a/tabpfn_client/tests/unit/test_prompt_agent.py
+++ b/tabpfn_client/tests/unit/test_prompt_agent.py
@@ -33,6 +33,7 @@ class TestPromptAgent(unittest.TestCase):
         )
         mock_auth_client.validate_email.return_value = (True, "")
         PromptAgent.prompt_and_set_token(user_auth_handler=mock_auth_client)
+        PromptAgent.prompt_access_token_information()
         mock_auth_client.set_token_by_registration.assert_called_once()
 
     @patch("getpass.getpass", side_effect=["password123"])


### PR DESCRIPTION
### Change Description

*Try to be precise. You can additionally add comments to your PR, this might help the reviewer a lot.*
Enhancement to set the access token if the user already has it. 
- The user can now set the token via  init(access_token="access_token"). If the access token is valid we will use it, otherwise the pre-existing prompting will continue.
- Also the user can view his/her token by get_token() directly.
- Additional Information regarding access token can also be found in all the above functionalities.
- Test cases have been updated and added.
- Readme.md has been updated as per functionality.
- Fixed Issues in resetting token. Earlier it was just deleting the file but not clearing the existing cache and was not updating the existing config.
- Also gave a temporary fix for reverify email() which has been fixed thoroughly in hashing PR.  

**If you used new dependencies: Did you add them to `requirements.txt`?**

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**
@liam-sbhoo 
## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**
No

**Does this PR break the user interface? If so, why?**
No
---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
