### PR TITLE
Add dataset cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.0.23"
+version = "0.0.24"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]
 

--- a/quick_test.py
+++ b/quick_test.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     print("predicting")
     print(tabpfn.predict(X_test))
     print("predicting_proba")
-    # print(tabpfn.predict_proba(X_test))
+    print(tabpfn.predict_proba(X_test))
 
     print(UserDataClient().get_data_summary())
 

--- a/quick_test.py
+++ b/quick_test.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     print("predicting")
     print(tabpfn.predict(X_test))
     print("predicting_proba")
-    print(tabpfn.predict_proba(X_test))
+    # print(tabpfn.predict_proba(X_test))
 
     print(UserDataClient().get_data_summary())
 

--- a/quick_test.py
+++ b/quick_test.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
         X, y, test_size=0.33, random_state=42
     )
 
-    tabpfn = TabPFNClassifier(model="latest_tabpfn_hosted", n_estimators=3)
+    tabpfn = TabPFNClassifier(n_estimators=3)
     # print("checking estimator", check_estimator(tabpfn))
     tabpfn.fit(X_train[:99], y_train[:99])
     print("predicting")
@@ -36,7 +36,7 @@ if __name__ == "__main__":
         X, y, test_size=0.33, random_state=42
     )
 
-    tabpfn = TabPFNRegressor(model="latest_tabpfn_hosted", n_estimators=3)
+    tabpfn = TabPFNRegressor(n_estimators=3)
     # print("checking estimator", check_estimator(tabpfn))
     tabpfn.fit(X_train[:99], y_train[:99])
     print("predicting reg")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ omegaconf>=2.3.0
 pandas>=1.3.0
 password-strength
 scikit-learn>=1.5.2
+cityhash

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -82,6 +82,7 @@ class DatasetCacheManager:
         """
         Saves the current cache to disk.
         """
+        os.makedirs(os.path.dirname(self.file_path), exist_ok=True)
         with open(self.file_path, "w") as file:
             json.dump(self.cache, file)
 

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -263,7 +263,7 @@ class ServiceClient:
         for attempt in range(max_attempts):
             try:
                 response = self._make_prediction_request(
-                    train_set_uid, cached_test_set_uid, x_test_serialized, params
+                    cached_test_set_uid, x_test_serialized, params
                 )
                 self._validate_response(response, "predict")
                 break  # Successful response, exit the retry loop
@@ -311,9 +311,7 @@ class ServiceClient:
 
         return result
 
-    def _make_prediction_request(
-        self, train_set_uid, test_set_uid, x_test_serialized, params
-    ):
+    def _make_prediction_request(self, test_set_uid, x_test_serialized, params):
         """
         Helper function to make the prediction request to the server.
         """

--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -252,8 +252,8 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin, TabPFNModelSelection):
 
         if config.g_tabpfn_config.use_server:
             self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
-            self._last_train_X = X
-            self._last_train_y = y
+            self.last_train_X = X
+            self.last_train_y = y
             self.fitted_ = True
         else:
             raise NotImplementedError(
@@ -283,8 +283,8 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin, TabPFNModelSelection):
             task="classification",
             train_set_uid=self.last_train_set_uid,
             config=estimator_param,
-            X_train=self._last_train_X,
-            y_train=self._last_train_y,
+            X_train=self.last_train_X,
+            y_train=self.last_train_y,
         )["probas"]
 
 
@@ -407,8 +407,8 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
 
         if config.g_tabpfn_config.use_server:
             self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
-            self._last_train_X = X
-            self._last_train_y = y
+            self.last_train_X = X
+            self.last_train_y = y
             self.fitted_ = True
         else:
             raise NotImplementedError(
@@ -443,8 +443,8 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
             task="regression",
             train_set_uid=self.last_train_set_uid,
             config=estimator_param,
-            X_train=self._last_train_X,
-            y_train=self._last_train_y,
+            X_train=self.last_train_X,
+            y_train=self.last_train_y,
         )
 
 

--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -224,6 +224,8 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin, TabPFNModelSelection):
         self.add_fingerprint_features = add_fingerprint_features
         self.subsample_samples = subsample_samples
         self.last_train_set_uid = None
+        self.last_train_X = None
+        self.last_train_y = None
 
     def _validate_targets_and_classes(self, y) -> np.ndarray:
         from sklearn.utils import column_or_1d
@@ -250,6 +252,8 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin, TabPFNModelSelection):
 
         if config.g_tabpfn_config.use_server:
             self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
+            self._last_train_X = X
+            self._last_train_y = y
             self.fitted_ = True
         else:
             raise NotImplementedError(
@@ -279,6 +283,8 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin, TabPFNModelSelection):
             task="classification",
             train_set_uid=self.last_train_set_uid,
             config=estimator_param,
+            X_train=self._last_train_X,
+            y_train=self._last_train_y,
         )["probas"]
 
 
@@ -390,6 +396,8 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
         self.super_bar_dist_averaging = super_bar_dist_averaging
         self.subsample_samples = subsample_samples
         self.last_train_set_uid = None
+        self.last_train_X = None
+        self.last_train_y = None
 
     def fit(self, X, y):
         # assert init() is called
@@ -399,6 +407,8 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
 
         if config.g_tabpfn_config.use_server:
             self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
+            self._last_train_X = X
+            self._last_train_y = y
             self.fitted_ = True
         else:
             raise NotImplementedError(
@@ -433,6 +443,8 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
             task="regression",
             train_set_uid=self.last_train_set_uid,
             config=estimator_param,
+            X_train=self._last_train_X,
+            y_train=self._last_train_y,
         )
 
 

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -194,10 +194,14 @@ class InferenceClient(ServiceClientWrapper):
         task: Literal["classification", "regression"],
         train_set_uid: str,
         config=None,
+        X_train=None,
+        y_train=None,
     ):
         return self.service_client.predict(
             train_set_uid=train_set_uid,
             x_test=X,
             tabpfn_config=config,
             task=task,
+            X_train=X_train,
+            y_train=y_train,
         )

--- a/tabpfn_client/tests/integration/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/integration/test_tabpfn_classifier.py
@@ -41,7 +41,7 @@ class TestTabPFNClassifier(unittest.TestCase):
 
         # mock fitting
         mock_server.router.post(mock_server.endpoints.upload_train_set.path).respond(
-            200, json={"train_set_uid": 5}
+            200, json={"train_set_uid": "5"}
         )
         tabpfn.fit(self.X_train, self.y_train)
 
@@ -51,7 +51,8 @@ class TestTabPFNClassifier(unittest.TestCase):
             json={
                 "classification": np.random.rand(
                     len(self.X_test), len(np.unique(self.y_train))
-                ).tolist()
+                ).tolist(),
+                "test_set_uid": "6",
             },
         )
         pred = tabpfn.predict(self.X_test)

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -1,11 +1,13 @@
+import os
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
 import numpy as np
 
 from tabpfn_client.client import ServiceClient
+from tabpfn_client.constants import CACHE_DIR
 from tabpfn_client.tests.mock_tabpfn_server import with_mock_server
 
 
@@ -18,6 +20,14 @@ class TestServiceClient(unittest.TestCase):
         )
 
         self.client = ServiceClient()
+        self.client._cache_manager.file_path = CACHE_DIR / "test_dataset_cache"
+        self.client._cache_manager.load_cache()
+
+    def tearDown(self):
+        try:
+            os.remove(CACHE_DIR / "test_dataset_cache")
+        except OSError:
+            pass
 
     @with_mock_server()
     def test_try_connection(self, mock_server):
@@ -183,7 +193,7 @@ class TestServiceClient(unittest.TestCase):
         self.client.authorize("dummy_token")
         self.client.upload_train_set(self.X_train, self.y_train)
 
-        dummy_result = {"classification": [1, 2, 3]}
+        dummy_result = {"test_set_uid": "dummy_uid", "classification": [1, 2, 3]}
         mock_server.router.post(mock_server.endpoints.predict.path).respond(
             200, json=dummy_result
         )
@@ -231,3 +241,224 @@ class TestServiceClient(unittest.TestCase):
         response.json.return_value = {"detail": "Some other error"}
         r = self.client._validate_response(response, "test", only_version_check=True)
         self.assertIsNone(r)
+
+    @with_mock_server()
+    def test_upload_train_set_with_caching(self, mock_server):
+        """
+        Test that uploading the same training set multiple times uses the cache and
+        only calls the upload_train_set endpoint once.
+        """
+        self.client.authorize("dummy_access_token")
+
+        # Mock the upload_train_set endpoint to return a fixed train_set_uid
+        with patch.object(
+            self.client.httpx_client, "post", wraps=self.client.httpx_client.post
+        ) as mock_post:
+            # Set up the mock response
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"train_set_uid": "dummy_train_set_uid"}
+            mock_post.return_value = mock_response
+
+            # First upload
+            train_set_uid1 = self.client.upload_train_set(self.X_train, self.y_train)
+
+            # Second upload with the same data
+            train_set_uid2 = self.client.upload_train_set(self.X_train, self.y_train)
+
+            # The train_set_uid should be the same due to caching
+            self.assertEqual(train_set_uid1, train_set_uid2)
+
+            # The upload_train_set endpoint should have been called only once
+            mock_post.assert_called_once()
+
+    def test_predict_with_caching(self):
+        """
+        Test that making predictions with the same test set uses the cache and
+        avoids re-uploading the test set.
+        """
+        self.client.authorize("dummy_access_token")
+
+        # Mock the upload_train_set and predict endpoints
+        with patch.object(
+            self.client.httpx_client, "post", wraps=self.client.httpx_client.post
+        ) as mock_post:
+            # Mock responses
+            def side_effect(*args, **kwargs):
+                if (
+                    kwargs.get("url")
+                    == self.client.server_endpoints.upload_train_set.path
+                ):
+                    response = Mock()
+                    response.status_code = 200
+                    response.json.return_value = {
+                        "train_set_uid": "dummy_train_set_uid"
+                    }
+                    return response
+                elif kwargs.get("url") == self.client.server_endpoints.predict.path:
+                    response = Mock()
+                    response.status_code = 200
+                    response.json.return_value = {
+                        "classification": [1, 2, 3],
+                        "test_set_uid": "dummy_test_set_uid",
+                    }
+                    return response
+                else:
+                    return Mock(status_code=404)
+
+            mock_post.side_effect = side_effect
+
+            # Upload train set
+            train_set_uid = self.client.upload_train_set(self.X_train, self.y_train)
+
+            # First prediction
+            pred1 = self.client.predict(
+                train_set_uid=train_set_uid, x_test=self.X_test, task="classification"
+            )
+
+            # Second prediction with the same test set
+            pred2 = self.client.predict(
+                train_set_uid=train_set_uid, x_test=self.X_test, task="classification"
+            )
+
+            # The predictions should be the same
+            self.assertTrue(np.array_equal(pred1["probas"], pred2["probas"]))
+
+            # The predict endpoint should have been called twice
+            self.assertEqual(
+                mock_post.call_count, 3
+            )  # 1 for upload_train_set, 2 for predict
+
+            # Check that the test set was uploaded only once (first predict call)
+            upload_calls = [
+                call for call in mock_post.call_args_list if "files" in call[1]
+            ]
+            self.assertEqual(
+                len(upload_calls), 2
+            )  # 1 for train set, 1 for test set upload
+
+    def test_predict_with_invalid_cached_uids(self):
+        """
+        Test that when the cached UIDs are invalid, the client re-uploads the datasets
+        and retries the prediction.
+        """
+        self.client.authorize("dummy_access_token")
+
+        # Mock the upload_train_set and predict endpoints
+        with patch.object(
+            self.client.httpx_client, "post", wraps=self.client.httpx_client.post
+        ) as mock_post:
+            # Mock responses with side effects to simulate invalid cached UIDs
+            def side_effect(*args, **kwargs):
+                if (
+                    kwargs.get("url")
+                    == self.client.server_endpoints.upload_train_set.path
+                ):
+                    response = Mock()
+                    response.status_code = 200
+                    response.json.return_value = {
+                        "train_set_uid": "dummy_train_set_uid"
+                    }
+                    return response
+                elif kwargs.get("url") == self.client.server_endpoints.predict.path:
+                    # Simulate invalid UID on first call, success on second
+                    if side_effect.call_count == 2:
+                        response = Mock()
+                        response.status_code = 400
+                        response.json.return_value = {
+                            "detail": "Invalid train or test set uid"
+                        }
+                        return response
+                    else:
+                        response = Mock()
+                        response.status_code = 200
+                        response.json.return_value = {
+                            "classification": [1, 2, 3],
+                            "test_set_uid": "new_dummy_test_set_uid",
+                        }
+                        return response
+                else:
+                    return Mock(status_code=404)
+
+            side_effect.call_count = 0
+
+            def side_effect_counter(*args, **kwargs):
+                side_effect.call_count += 1
+                return side_effect(*args, **kwargs)
+
+            mock_post.side_effect = side_effect_counter
+
+            # Upload train set
+            train_set_uid = self.client.upload_train_set(self.X_train, self.y_train)
+
+            # Attempt prediction, which should fail and trigger retry
+            pred = self.client.predict(
+                train_set_uid=train_set_uid, x_test=self.X_test, task="classification"
+            )
+
+            # The predictions should be as expected
+            self.assertTrue(np.array_equal(pred["probas"], [1, 2, 3]))
+
+            # The predict endpoint should have been called twice due to retry
+            self.assertEqual(
+                mock_post.call_count, 4
+            )  # 1 upload_train_set + 2 predict + 1 re-upload
+
+            # Ensure that upload_train_set was called again (re-upload)
+            upload_calls = [
+                call
+                for call in mock_post.call_args_list
+                if call.kwargs.get("url")
+                == self.client.server_endpoints.upload_train_set.path
+            ]
+            self.assertEqual(len(upload_calls), 2)
+
+    def test_dataset_cache_manager(self):
+        """
+        Test the DatasetCacheManager's basic functionality: adding, retrieving,
+        and deleting dataset UIDs based on hashes.
+        """
+        # Create a fresh cache manager
+        cache_manager = self.client._cache_manager
+
+        # Mock dataset hashes and UIDs
+        dataset_hash_1 = "hash1"
+        dataset_uid_1 = "uid1"
+        dataset_hash_2 = "hash2"
+        dataset_uid_2 = "uid2"
+
+        # Add datasets to cache
+        cache_manager.add_dataset(dataset_hash_1, dataset_uid_1)
+        cache_manager.add_dataset(dataset_hash_2, dataset_uid_2)
+
+        # Retrieve datasets from cache
+        retrieved_uid_1 = cache_manager.get_dataset_uid(dataset_hash_1)
+        retrieved_uid_2 = cache_manager.get_dataset_uid(dataset_hash_2)
+
+        self.assertEqual(retrieved_uid_1, dataset_uid_1)
+        self.assertEqual(retrieved_uid_2, dataset_uid_2)
+
+        # Delete a dataset by UID
+        deleted_hash = cache_manager.delete_dataset_by_uid(dataset_uid_1)
+        self.assertEqual(deleted_hash, dataset_hash_1)
+
+        # Ensure the deleted dataset is no longer in the cache
+        self.assertIsNone(cache_manager.get_dataset_uid(dataset_hash_1))
+
+    def test_cache_limit(self):
+        """
+        Test that the cache does not exceed its limit and evicts the oldest entries.
+        """
+        cache_manager = self.client._cache_manager
+        cache_manager.cache_limit = 3  # Set a small limit for testing
+
+        # Add more datasets than the cache limit
+        for i in range(5):
+            cache_manager.add_dataset(f"hash{i}", f"uid{i}")
+
+        # The cache should only contain the last 3 added datasets
+        expected_hashes = ["hash2", "hash3", "hash4"]
+        actual_hashes = list(cache_manager.cache.keys())
+
+        self.assertEqual(actual_hashes, expected_hashes)
+        self.assertEqual(len(cache_manager.cache), 3)

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -20,8 +20,12 @@ class TestServiceClient(unittest.TestCase):
         )
 
         self.client = ServiceClient()
-        self.client._cache_manager.file_path = CACHE_DIR / "test_dataset_cache"
-        self.client._cache_manager.cache = self.client._cache_manager.load_cache()
+        self.client.dataset_uid_cache_manager.file_path = (
+            CACHE_DIR / "test_dataset_cache"
+        )
+        self.client.dataset_uid_cache_manager.cache = (
+            self.client.dataset_uid_cache_manager.load_cache()
+        )
 
     def tearDown(self):
         try:
@@ -419,7 +423,7 @@ class TestServiceClient(unittest.TestCase):
         and deleting dataset UIDs based on hashes.
         """
         # Create a fresh cache manager
-        cache_manager = self.client._cache_manager
+        cache_manager = self.client.dataset_uid_cache_manager
 
         # Mock dataset hashes and UIDs
         dataset_hash_1 = "hash1"
@@ -428,8 +432,8 @@ class TestServiceClient(unittest.TestCase):
         dataset_uid_2 = "uid2"
 
         # Add datasets to cache
-        cache_manager.add_dataset(dataset_hash_1, dataset_uid_1)
-        cache_manager.add_dataset(dataset_hash_2, dataset_uid_2)
+        cache_manager.add_dataset_uid(dataset_hash_1, dataset_uid_1)
+        cache_manager.add_dataset_uid(dataset_hash_2, dataset_uid_2)
 
         # Retrieve datasets from cache
         retrieved_uid_1 = cache_manager.get_dataset_uid(dataset_hash_1)
@@ -439,7 +443,7 @@ class TestServiceClient(unittest.TestCase):
         self.assertEqual(retrieved_uid_2, dataset_uid_2)
 
         # Delete a dataset by UID
-        deleted_hash = cache_manager.delete_dataset_by_uid(dataset_uid_1)
+        deleted_hash = cache_manager.delete_uid(dataset_uid_1)
         self.assertEqual(deleted_hash, dataset_hash_1)
 
         # Ensure the deleted dataset is no longer in the cache
@@ -449,12 +453,12 @@ class TestServiceClient(unittest.TestCase):
         """
         Test that the cache does not exceed its limit and evicts the oldest entries.
         """
-        cache_manager = self.client._cache_manager
+        cache_manager = self.client.dataset_uid_cache_manager
         cache_manager.cache_limit = 3  # Set a small limit for testing
 
         # Add more datasets than the cache limit
         for i in range(5):
-            cache_manager.add_dataset(f"hash{i}", f"uid{i}")
+            cache_manager.add_dataset_uid(f"hash{i}", f"uid{i}")
 
         # The cache should only contain the last 3 added datasets
         expected_hashes = ["hash2", "hash3", "hash4"]

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -176,11 +176,11 @@ class TestServiceClient(unittest.TestCase):
 
     @with_mock_server()
     def test_predict_with_valid_train_set_and_test_set(self, mock_server):
-        dummy_json = {"train_set_uid": 5}
+        dummy_json = {"train_set_uid": "5"}
         mock_server.router.post(mock_server.endpoints.upload_train_set.path).respond(
             200, json=dummy_json
         )
-
+        self.client.authorize("dummy_token")
         self.client.upload_train_set(self.X_train, self.y_train)
 
         dummy_result = {"classification": [1, 2, 3]}

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -21,7 +21,7 @@ class TestServiceClient(unittest.TestCase):
 
         self.client = ServiceClient()
         self.client._cache_manager.file_path = CACHE_DIR / "test_dataset_cache"
-        self.client._cache_manager.load_cache()
+        self.client._cache_manager.cache = self.client._cache_manager.load_cache()
 
     def tearDown(self):
         try:

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -397,7 +397,11 @@ class TestServiceClient(unittest.TestCase):
 
             # Attempt prediction, which should fail and trigger retry
             pred = self.client.predict(
-                train_set_uid=train_set_uid, x_test=self.X_test, task="classification"
+                train_set_uid=train_set_uid,
+                x_test=self.X_test,
+                task="classification",
+                X_train=self.X_train,
+                y_train=self.y_train,
             )
 
             # The predictions should be as expected
@@ -426,19 +430,22 @@ class TestServiceClient(unittest.TestCase):
         cache_manager = self.client.dataset_uid_cache_manager
 
         # Mock dataset hashes and UIDs
-        dataset_hash_1 = "hash1"
+        dataset_1 = "data1"
         dataset_uid_1 = "uid1"
-        dataset_hash_2 = "hash2"
+        dataset_2 = "data2"
         dataset_uid_2 = "uid2"
+
+        # Get hash by trying to get dataset_uid from cache
+        _, dataset_hash_1 = cache_manager.get_dataset_uid(dataset_1)
+        _, dataset_hash_2 = cache_manager.get_dataset_uid(dataset_2)
 
         # Add datasets to cache
         cache_manager.add_dataset_uid(dataset_hash_1, dataset_uid_1)
         cache_manager.add_dataset_uid(dataset_hash_2, dataset_uid_2)
 
         # Retrieve datasets from cache
-        retrieved_uid_1 = cache_manager.get_dataset_uid(dataset_hash_1)
-        retrieved_uid_2 = cache_manager.get_dataset_uid(dataset_hash_2)
-
+        retrieved_uid_1, _ = cache_manager.get_dataset_uid(dataset_1)
+        retrieved_uid_2, _ = cache_manager.get_dataset_uid(dataset_2)
         self.assertEqual(retrieved_uid_1, dataset_uid_1)
         self.assertEqual(retrieved_uid_2, dataset_uid_2)
 
@@ -447,7 +454,7 @@ class TestServiceClient(unittest.TestCase):
         self.assertEqual(deleted_hash, dataset_hash_1)
 
         # Ensure the deleted dataset is no longer in the cache
-        self.assertIsNone(cache_manager.get_dataset_uid(dataset_hash_1))
+        self.assertIsNone(cache_manager.get_dataset_uid(dataset_1)[0])
 
     def test_cache_limit(self):
         """

--- a/tabpfn_client/tests/unit/test_service_wrapper.py
+++ b/tabpfn_client/tests/unit/test_service_wrapper.py
@@ -15,6 +15,9 @@ class TestUserAuthClient(unittest.TestCase):
     They do not guarantee if the response from the server is correct.
     """
 
+    def setUp(self):
+        ServiceClient().reset_authorization()
+
     def tearDown(self):
         ServiceClient().delete_instance()
 

--- a/tabpfn_client/tests/unit/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_classifier.py
@@ -52,7 +52,7 @@ class TestTabPFNClassifierInit(unittest.TestCase):
         # mock server connection
         mock_server.router.get(mock_server.endpoints.root.path).respond(200)
         mock_server.router.post(mock_server.endpoints.upload_train_set.path).respond(
-            200, json={"train_set_uid": 5}
+            200, json={"train_set_uid": "5"}
         )
 
         mock_server.router.get(
@@ -61,7 +61,9 @@ class TestTabPFNClassifierInit(unittest.TestCase):
 
         mock_predict_response = [[1, 0.0], [0.9, 0.1], [0.01, 0.99]]
         predict_route = mock_server.router.post(mock_server.endpoints.predict.path)
-        predict_route.respond(200, json={"classification": mock_predict_response})
+        predict_route.respond(
+            200, json={"classification": mock_predict_response, "test_set_uid": "6"}
+        )
 
         init(use_server=True)
 

--- a/tabpfn_client/tests/unit/test_tabpfn_regressor.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_regressor.py
@@ -52,7 +52,7 @@ class TestTabPFNRegressorInit(unittest.TestCase):
         # mock server connection
         mock_server.router.get(mock_server.endpoints.root.path).respond(200)
         mock_server.router.post(mock_server.endpoints.upload_train_set.path).respond(
-            200, json={"train_set_uid": 5}
+            200, json={"train_set_uid": "5"}
         )
         mock_server.router.get(
             mock_server.endpoints.retrieve_greeting_messages.path
@@ -64,7 +64,9 @@ class TestTabPFNRegressorInit(unittest.TestCase):
             "mode": [120, 220, 320],
         }
         predict_route = mock_server.router.post(mock_server.endpoints.predict.path)
-        predict_route.respond(200, json={"regression": mock_predict_response})
+        predict_route.respond(
+            200, json={"regression": mock_predict_response, "test_set_uid": "6"}
+        )
 
         init(use_server=True)
 


### PR DESCRIPTION
### Change Description

*Try to be precise. You can additionally add comments to your PR, this might help the reviewer a lot.*

This PR adds a dataset cache to prevent repeated upload of datasets. There are also few changes in the corresponding [server PR](https://github.com/automl/tabpfn-server/pull/80). More concretely, this PR adds the following things:
- Cache system: The DatasetCacheManager keeps track of the cache in form of an OrderedDict, which contains a map of dataset hash to dataset uid for the last 50 uploaded datasets. To avoid specific edge cases (like change of user account or same test set for different train sets), the dataset is hashed together with the user's token and train_set_uid (in the case of the test set). For hashing I decided to use CityHash128 because in my tests it was way faster for large datasets than other common hashing algorithms. The cache is stored in a file in the .tabpfn folder.
- Caching in train set upload: When fit is called and the train set is in the cache, then no request is sent to the server at all.
- Caching in predict: If the test set is cached, then test_set_uid is sent instead of the actual test set. This part involves now a retry mechanism (implemented with the for loop) in case of any failures with cashing. This could for instance be needed if any datasets on server side were deleted by us or the cache file was manually changed. But this should almost never happen. Then, either cashed train_set_uid or test_set_uid can be incorrect, so both datasets are uploaded again.

Please check this PR carefully for the case that I missed any further edge cases :)

**If you used new dependencies: Did you add them to `requirements.txt`?**

yes

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**

@SamuelGabriel 

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**

**Does this PR break the user interface? If so, why?**

Yes, because now just the cached dataset uids might be sent to server.

---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
