### PR TITLE
Make login flow a tad nicer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,25 +54,18 @@ probabilities = model.predict_proba(X_test)
 - [Interactive Colab Tutorial](https://colab.research.google.com/drive/1ns_KdtyHgl29AOVwTw9c-DZrPj7fx_DW?usp=sharing)
 
 ## 🔑 Authentication
+You can retrieve your access token
 
 ### Save Your Token
 ```python
-from tabpfn_client import config
-
-# Retrieve current token
-with open(config.g_tabpfn_config.user_auth_handler.CACHED_TOKEN_FILE, 'r') as file:
-    token = file.read()
-print(f"TOKEN: {token}")
+import tabpfn_client
+token = tabpfn_client.get_access_token()
 ```
 
-### Use Saved Token
-```python
-from tabpfn_client import config
+and login (on another machine) using your access token, skipping the interactive flow, use:
 
-# Initialize with saved token
-service_client = config.ServiceClient()
-config.g_tabpfn_config.user_auth_handler = config.UserAuthenticationClient(service_client=service_client)
-user_auth = config.g_tabpfn_config.user_auth_handler.set_token(token)
+```python
+tabpfn_client.set_access_token(token)
 ```
 
 ## 🤝 Join Our Community
@@ -106,4 +99,15 @@ Additionally, it is recommended that developers install the ruff extension in th
 if [ -d "dist" ]; then rm -rf dist/*; fi
 python3 -m pip install --upgrade build; python3 -m build
 python3 -m twine upload --repository pypi dist/*
+```
+
+
+### Access/Delete Personal Information
+
+You can use our `UserDataClient` to access and delete personal information.
+
+```python
+from tabpfn_client import UserDataClient
+
+print(UserDataClient.get_data_summary())
 ```

--- a/quick_test.py
+++ b/quick_test.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     print("predicting_proba")
     print(tabpfn.predict_proba(X_test))
 
-    print(UserDataClient().get_data_summary())
+    print(UserDataClient.get_data_summary())
 
     X, y = load_diabetes(return_X_y=True)
     X_train, X_test, y_train, y_test = train_test_split(
@@ -42,4 +42,4 @@ if __name__ == "__main__":
     print("predicting reg")
     print(tabpfn.predict(X_test))
 
-    print(UserDataClient().get_data_summary())
+    print(UserDataClient.get_data_summary())

--- a/tabpfn_client/__init__.py
+++ b/tabpfn_client/__init__.py
@@ -1,5 +1,13 @@
-from tabpfn_client.config import init, reset
+from tabpfn_client.config import init, reset, get_access_token, set_access_token
 from tabpfn_client.estimator import TabPFNClassifier, TabPFNRegressor
 from tabpfn_client.service_wrapper import UserDataClient
 
-__all__ = ["init", "reset", "TabPFNClassifier", "TabPFNRegressor", "UserDataClient"]
+__all__ = [
+    "init",
+    "reset",
+    "TabPFNClassifier",
+    "TabPFNRegressor",
+    "UserDataClient",
+    "get_access_token",
+    "set_access_token",
+]

--- a/tabpfn_client/config.py
+++ b/tabpfn_client/config.py
@@ -1,41 +1,41 @@
 import shutil
 
-from tabpfn_client.service_wrapper import UserAuthenticationClient, InferenceClient
 from tabpfn_client.client import ServiceClient
+from tabpfn_client.service_wrapper import UserAuthenticationClient
 from tabpfn_client.constants import CACHE_DIR
 from tabpfn_client.prompt_agent import PromptAgent
 
 
-class TabPFNConfig:
+class Config:
+    def __new__(cls, *args, **kwargs):
+        """
+        This class is a singleton and should not be instantiated directly.
+        Only use class methods.
+        """
+        raise TypeError("Cannot instantiate this class")
+
     is_initialized = False
     use_server = False
-    user_auth_handler = None
-    inference_handler = None
-
-
-g_tabpfn_config = TabPFNConfig()
 
 
 def init(use_server=True):
     # initialize config
-    use_server = use_server
-    global g_tabpfn_config
+    Config.use_server = use_server
 
-    if g_tabpfn_config.is_initialized:
+    if Config.is_initialized:
         # Only do the following if the initialization has not been done yet
         return
 
     if use_server:
-        service_client = ServiceClient()
-        user_auth_handler = UserAuthenticationClient(service_client)
-
         # check connection to server
-        if not user_auth_handler.is_accessible_connection():
+        if not UserAuthenticationClient.is_accessible_connection():
             raise RuntimeError(
                 "TabPFN is inaccessible at the moment, please try again later."
             )
 
-        is_valid_token_set = user_auth_handler.try_reuse_existing_token()
+        is_valid_token_set = UserAuthenticationClient.try_reuse_existing_token()
+
+        print(f"is_valid_token_set: {is_valid_token_set}")
 
         if isinstance(is_valid_token_set, bool) and is_valid_token_set:
             PromptAgent.prompt_reusing_existing_token()
@@ -43,7 +43,7 @@ def init(use_server=True):
             isinstance(is_valid_token_set, tuple) and is_valid_token_set[1] is not None
         ):
             print("Your email is not verified. Please verify your email to continue...")
-            PromptAgent.reverify_email(is_valid_token_set[1], user_auth_handler)
+            PromptAgent.reverify_email(is_valid_token_set[1])
         else:
             PromptAgent.prompt_welcome()
             if not PromptAgent.prompt_terms_and_cond():
@@ -52,32 +52,35 @@ def init(use_server=True):
                 )
 
             # prompt for login / register
-            PromptAgent.prompt_and_set_token(user_auth_handler)
+            print("prompt_and_set_token")
+            PromptAgent.prompt_and_set_token()
 
         # Print new greeting messages. If there are no new messages, nothing will be printed.
         PromptAgent.prompt_retrieved_greeting_messages(
-            user_auth_handler.retrieve_greeting_messages()
+            UserAuthenticationClient.retrieve_greeting_messages()
         )
 
-        g_tabpfn_config.use_server = True
-        g_tabpfn_config.user_auth_handler = user_auth_handler
-        g_tabpfn_config.inference_handler = InferenceClient(service_client)
-
+        Config.use_server = True
+        Config.is_initialized = True
     else:
         raise RuntimeError("Local inference is not supported yet.")
-        # g_tabpfn_config.use_server = False
-
-    g_tabpfn_config.is_initialized = True
 
 
 def reset():
-    # reset config
-    global g_tabpfn_config
-    g_tabpfn_config = TabPFNConfig()
-
+    Config.is_initialized = False
     # reset user auth handler
-    if g_tabpfn_config.use_server:
-        g_tabpfn_config.user_auth_handler.reset_cache()
+    if Config.use_server:
+        UserAuthenticationClient.reset_cache()
 
     # remove cache dir
     shutil.rmtree(CACHE_DIR, ignore_errors=True)
+
+
+def get_access_token() -> str:
+    init()
+    return ServiceClient.get_access_token()
+
+
+def set_access_token(access_token: str):
+    UserAuthenticationClient.set_token(access_token)
+    Config.is_initialized = True

--- a/tabpfn_client/config.py
+++ b/tabpfn_client/config.py
@@ -35,7 +35,6 @@ def init(use_server=True):
 
         is_valid_token_set = UserAuthenticationClient.try_reuse_existing_token()
 
-
         if isinstance(is_valid_token_set, bool) and is_valid_token_set:
             PromptAgent.prompt_reusing_existing_token()
         elif (

--- a/tabpfn_client/config.py
+++ b/tabpfn_client/config.py
@@ -35,7 +35,6 @@ def init(use_server=True):
 
         is_valid_token_set = UserAuthenticationClient.try_reuse_existing_token()
 
-        print(f"is_valid_token_set: {is_valid_token_set}")
 
         if isinstance(is_valid_token_set, bool) and is_valid_token_set:
             PromptAgent.prompt_reusing_existing_token()

--- a/tabpfn_client/config.py
+++ b/tabpfn_client/config.py
@@ -51,7 +51,6 @@ def init(use_server=True):
                 )
 
             # prompt for login / register
-            print("prompt_and_set_token")
             PromptAgent.prompt_and_set_token()
 
         # Print new greeting messages. If there are no new messages, nothing will be printed.

--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -3,11 +3,12 @@ import logging
 from dataclasses import dataclass, asdict
 
 import numpy as np
-from tabpfn_client import init
+from tabpfn_client.config import init
 from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
 from sklearn.utils.validation import check_is_fitted
 
-from tabpfn_client import config
+from tabpfn_client.config import Config
+from tabpfn_client.service_wrapper import InferenceClient
 
 logger = logging.getLogger(__name__)
 
@@ -250,8 +251,8 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin, TabPFNModelSelection):
         validate_data_size(X, y)
         self._validate_targets_and_classes(y)
 
-        if config.g_tabpfn_config.use_server:
-            self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
+        if Config.use_server:
+            self.last_train_set_uid = InferenceClient.fit(X, y)
             self.last_train_X = X
             self.last_train_y = y
             self.fitted_ = True
@@ -278,7 +279,7 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin, TabPFNModelSelection):
                 "classification", estimator_param.pop("model")
             )
 
-        return config.g_tabpfn_config.inference_handler.predict(
+        return InferenceClient.predict(
             X,
             task="classification",
             train_set_uid=self.last_train_set_uid,
@@ -405,8 +406,8 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
 
         validate_data_size(X, y)
 
-        if config.g_tabpfn_config.use_server:
-            self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
+        if Config.use_server:
+            self.last_train_set_uid = InferenceClient.fit(X, y)
             self.last_train_X = X
             self.last_train_y = y
             self.fitted_ = True
@@ -438,7 +439,7 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
                 "regression", estimator_param.pop("model")
             )
 
-        return config.g_tabpfn_config.inference_handler.predict(
+        return InferenceClient.predict(
             X,
             task="regression",
             train_set_uid=self.last_train_set_uid,

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -5,8 +5,8 @@
 
 # production
 protocol: "https"
-host: "tabpfn-server-wjedmz7r5a-ez.a.run.app"
-# host: tabpfn-server-preprod-wjedmz7r5a-ez.a.run.app   # preprod
+# host: "tabpfn-server-wjedmz7r5a-ez.a.run.app"
+host: tabpfn-server-preprod-wjedmz7r5a-ez.a.run.app   # preprod
 port: "443"
 endpoints:
   root:

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -5,8 +5,7 @@
 
 # production
 protocol: "https"
-# host: "tabpfn-server-wjedmz7r5a-ez.a.run.app"
-host: tabpfn-server-preprod-wjedmz7r5a-ez.a.run.app   # preprod
+host: "tabpfn-server-wjedmz7r5a-ez.a.run.app"
 port: "443"
 endpoints:
   root:

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -82,7 +82,6 @@ class UserAuthenticationClient(ServiceClientWrapper, Singleton):
         else:
             access_token = ServiceClient.get_access_token()
 
-        print(f"{ServiceClient.get_access_token()=}, {cls.CACHED_TOKEN_FILE.exists()=}")
 
         is_valid = ServiceClient.is_auth_token_outdated(access_token)
         if is_valid is False:

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -82,7 +82,6 @@ class UserAuthenticationClient(ServiceClientWrapper, Singleton):
         else:
             access_token = ServiceClient.get_access_token()
 
-
         is_valid = ServiceClient.is_auth_token_outdated(access_token)
         if is_valid is False:
             cls._reset_token()

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -4,128 +4,147 @@ from typing import Literal
 
 from tabpfn_client.client import ServiceClient
 from tabpfn_client.constants import CACHE_DIR
-from tabpfn_client.prompt_agent import PromptAgent
+from tabpfn_client.tabpfn_common_utils.utils import Singleton
 
 logger = logging.getLogger(__name__)
 
 
 class ServiceClientWrapper:
-    def __init__(self, service_client: ServiceClient):
-        self.service_client = service_client
+    pass
 
 
-class UserAuthenticationClient(ServiceClientWrapper):
+# Singleton class for user authentication
+class UserAuthenticationClient(ServiceClientWrapper, Singleton):
     """
     Wrapper of ServiceClient to handle user authentication, including:
     - user registration and login
     - access token caching
 
+    This is implemented as a singleton class with classmethods.
     """
 
     CACHED_TOKEN_FILE = CACHE_DIR / "config"
 
-    def is_accessible_connection(self) -> bool:
-        return self.service_client.try_connection()
+    def __new__(self):
+        raise TypeError(
+            "This class should not be instantiated. Use classmethods instead."
+        )
 
-    def set_token(self, access_token: str):
-        self.service_client.authorize(access_token)
-        self.CACHED_TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
-        self.CACHED_TOKEN_FILE.write_text(access_token)
+    @classmethod
+    def is_accessible_connection(cls) -> bool:
+        return ServiceClient.try_connection()
 
-    def validate_email(self, email: str) -> tuple[bool, str]:
-        is_valid, message = self.service_client.validate_email(email)
+    @classmethod
+    def set_token(cls, access_token: str):
+        ServiceClient.authorize(access_token)
+        cls.CACHED_TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
+        cls.CACHED_TOKEN_FILE.write_text(access_token)
+
+    @classmethod
+    def validate_email(cls, email: str) -> tuple[bool, str]:
+        is_valid, message = ServiceClient.validate_email(email)
         return is_valid, message
 
+    @classmethod
     def set_token_by_registration(
-        self,
+        cls,
         email: str,
         password: str,
         password_confirm: str,
         validation_link: str,
         additional_info: dict,
     ) -> tuple[bool, str]:
-        is_created, message, access_token = self.service_client.register(
+        is_created, message, access_token = ServiceClient.register(
             email, password, password_confirm, validation_link, additional_info
         )
         if access_token is not None:
-            self.set_token(access_token)
+            cls.set_token(access_token)
         return is_created, message
 
-    def set_token_by_login(self, email: str, password: str) -> tuple[bool, str]:
-        access_token, message = self.service_client.login(email, password)
+    @classmethod
+    def set_token_by_login(cls, email: str, password: str) -> tuple[bool, str]:
+        access_token, message = ServiceClient.login(email, password)
 
         if access_token is None:
             return False, message
 
-        self.set_token(access_token)
+        cls.set_token(access_token)
         return True, message
 
-    def try_reuse_existing_token(self) -> bool | tuple[bool, str]:
-        if self.service_client.access_token is None:
-            if not self.CACHED_TOKEN_FILE.exists():
+    @classmethod
+    def try_reuse_existing_token(cls) -> bool | tuple[bool, str]:
+        if ServiceClient.get_access_token() is None:
+            if not cls.CACHED_TOKEN_FILE.exists():
                 return False
 
-            access_token = self.CACHED_TOKEN_FILE.read_text()
+            access_token = cls.CACHED_TOKEN_FILE.read_text()
 
         else:
-            access_token = self.service_client.access_token
+            access_token = ServiceClient.get_access_token()
 
-        is_valid = self.service_client.is_auth_token_outdated(access_token)
+        print(f"{ServiceClient.get_access_token()=}, {cls.CACHED_TOKEN_FILE.exists()=}")
+
+        is_valid = ServiceClient.is_auth_token_outdated(access_token)
         if is_valid is False:
-            self._reset_token()
+            cls._reset_token()
             return False
         elif is_valid is None:
             return False, access_token
 
         logger.debug(f"Reusing existing access token? {is_valid}")
-        self.set_token(access_token)
+        cls.set_token(access_token)
 
         return True
 
-    def get_password_policy(self):
-        return self.service_client.get_password_policy()
+    @classmethod
+    def get_password_policy(cls):
+        return ServiceClient.get_password_policy()
 
-    def reset_cache(self):
-        self._reset_token()
+    @classmethod
+    def reset_cache(cls):
+        cls._reset_token()
 
-    def _reset_token(self):
-        self.service_client.reset_authorization()
-        self.CACHED_TOKEN_FILE.unlink(missing_ok=True)
+    @classmethod
+    def _reset_token(cls):
+        ServiceClient.reset_authorization()
+        cls.CACHED_TOKEN_FILE.unlink(missing_ok=True)
 
-    def retrieve_greeting_messages(self):
-        return self.service_client.retrieve_greeting_messages()
+    @classmethod
+    def retrieve_greeting_messages(cls):
+        return ServiceClient.retrieve_greeting_messages()
 
-    def send_reset_password_email(self, email: str) -> tuple[bool, str]:
-        sent, message = self.service_client.send_reset_password_email(email)
+    @classmethod
+    def send_reset_password_email(cls, email: str) -> tuple[bool, str]:
+        sent, message = ServiceClient.send_reset_password_email(email)
         return sent, message
 
-    def send_verification_email(self, access_token: str) -> tuple[bool, str]:
-        sent, message = self.service_client.send_verification_email(access_token)
+    @classmethod
+    def send_verification_email(cls, access_token: str) -> tuple[bool, str]:
+        sent, message = ServiceClient.send_verification_email(access_token)
         return sent, message
 
 
-class UserDataClient(ServiceClientWrapper):
+class UserDataClient(ServiceClientWrapper, Singleton):
     """
     Wrapper of ServiceClient to handle user data, including:
     - query, or delete user account data
     - query, download, or delete uploaded data
     """
 
-    def __init__(self, service_client=ServiceClient()):
-        super().__init__(service_client)
-
-    def get_data_summary(self) -> {}:
+    @classmethod
+    def get_data_summary(cls) -> {}:
         try:
-            summary = self.service_client.get_data_summary()
+            summary = ServiceClient.get_data_summary()
         except RuntimeError as e:
             logging.error(f"Failed to get data summary: {e}")
             raise e
 
         return summary
 
-    def download_all_data(self, save_dir: Path = Path(".")) -> Path:
+    @classmethod
+    def download_all_data(cls, save_dir: Path = Path(".")) -> Path:
         try:
-            saved_path = self.service_client.download_all_data(save_dir)
+            saved_path = ServiceClient.download_all_data(save_dir)
         except RuntimeError as e:
             logging.error(f"Failed to download data: {e}")
             raise e
@@ -136,9 +155,10 @@ class UserDataClient(ServiceClientWrapper):
         logging.info(f"Data saved to {saved_path}")
         return saved_path
 
-    def delete_dataset(self, dataset_uid: str) -> [str]:
+    @classmethod
+    def delete_dataset(cls, dataset_uid: str) -> list[str]:
         try:
-            deleted_datasets = self.service_client.delete_dataset(dataset_uid)
+            deleted_datasets = ServiceClient.delete_dataset(dataset_uid)
         except RuntimeError as e:
             logging.error(f"Failed to delete dataset: {e}")
             raise e
@@ -147,9 +167,10 @@ class UserDataClient(ServiceClientWrapper):
 
         return deleted_datasets
 
-    def delete_all_datasets(self) -> [str]:
+    @classmethod
+    def delete_all_datasets(cls) -> list[str]:
         try:
-            deleted_datasets = self.service_client.delete_all_datasets()
+            deleted_datasets = ServiceClient.delete_all_datasets()
         except RuntimeError as e:
             logging.error(f"Failed to delete all datasets: {e}")
             raise e
@@ -158,10 +179,14 @@ class UserDataClient(ServiceClientWrapper):
 
         return deleted_datasets
 
-    def delete_user_account(self):
+    @classmethod
+    def delete_user_account(cls):
+        # local import to avoid circular import
+        from tabpfn_client.prompt_agent import PromptAgent
+
         confirm_pass = PromptAgent.prompt_confirm_password_for_user_account_deletion()
         try:
-            self.service_client.delete_user_account(confirm_pass)
+            ServiceClient.delete_user_account(confirm_pass)
         except RuntimeError as e:
             logging.error(f"Failed to delete user account: {e}")
             raise e
@@ -169,27 +194,25 @@ class UserDataClient(ServiceClientWrapper):
         PromptAgent.prompt_account_deleted()
 
 
-class InferenceClient(ServiceClientWrapper):
+class InferenceClient(ServiceClientWrapper, Singleton):
     """
     Wrapper of ServiceClient to handle inference, including:
     - fitting
     - prediction
     """
 
-    def __init__(self, service_client=ServiceClient()):
-        super().__init__(service_client)
+    def __new__(self):
+        raise TypeError(
+            "This class should not be instantiated. Use classmethods instead."
+        )
 
-    def fit(self, X, y) -> str:
-        if not self.service_client.is_initialized:
-            raise RuntimeError(
-                "Dear TabPFN User, please initialize the client first by verifying your E-mail address sent to your registered E-mail account."
-                "Please Note: The email verification token expires in 30 minutes."
-            )
+    @classmethod
+    def fit(cls, X, y) -> str:
+        return ServiceClient.upload_train_set(X, y)
 
-        return self.service_client.upload_train_set(X, y)
-
+    @classmethod
     def predict(
-        self,
+        cls,
         X,
         task: Literal["classification", "regression"],
         train_set_uid: str,
@@ -197,7 +220,7 @@ class InferenceClient(ServiceClientWrapper):
         X_train=None,
         y_train=None,
     ):
-        return self.service_client.predict(
+        return ServiceClient.predict(
             train_set_uid=train_set_uid,
             x_test=X,
             tabpfn_config=config,

--- a/tabpfn_client/tests/integration/test_server_config.py
+++ b/tabpfn_client/tests/integration/test_server_config.py
@@ -1,0 +1,19 @@
+import unittest
+import yaml
+import os
+
+
+class TestServerConfig(unittest.TestCase):
+    def setUp(self):
+        # Get the path to the config file relative to the test file
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        config_path = os.path.join(current_dir, "..", "..", "server_config.yaml")
+
+        with open(config_path, "r") as f:
+            self.config = yaml.safe_load(f)
+
+    def test_host_configuration(self):
+        expected_host = "tabpfn-server-wjedmz7r5a-ez.a.run.app"
+        self.assertEqual(
+            self.config["host"], expected_host, f"Host should be {expected_host}"
+        )

--- a/tabpfn_client/tests/integration/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/integration/test_tabpfn_classifier.py
@@ -1,18 +1,20 @@
 import unittest
+import importlib
 
 from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
 import numpy as np
 
+import tabpfn_client.client
 from tabpfn_client import init, reset
 from tabpfn_client import TabPFNClassifier
 from tabpfn_client.tests.mock_tabpfn_server import with_mock_server
 from tabpfn_client.service_wrapper import UserAuthenticationClient
-from tabpfn_client.client import ServiceClient
 
 
 class TestTabPFNClassifier(unittest.TestCase):
     def setUp(self):
+        importlib.reload(tabpfn_client.client)
         X, y = load_breast_cancer(return_X_y=True)
         self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(
             X, y, test_size=0.33, random_state=42
@@ -20,7 +22,7 @@ class TestTabPFNClassifier(unittest.TestCase):
 
     def tearDown(self):
         reset()
-        ServiceClient().delete_instance()
+        importlib.reload(tabpfn_client.client)
 
     @with_mock_server()
     def test_use_remote_tabpfn_classifier(self, mock_server):

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -290,7 +290,9 @@ class TestServiceClient(unittest.TestCase):
         # Mock the upload_train_set and predict endpoints
         with (
             patch.object(
-                ServiceClient.httpx_client, "post", wraps=ServiceClient.httpx_client.post
+                ServiceClient.httpx_client,
+                "post",
+                wraps=ServiceClient.httpx_client.post,
             ) as mock_post,
             patch.object(
                 ServiceClient.httpx_client,
@@ -367,7 +369,9 @@ class TestServiceClient(unittest.TestCase):
         # Mock the upload_train_set and predict endpoints
         with (
             patch.object(
-                ServiceClient.httpx_client, "post", wraps=ServiceClient.httpx_client.post
+                ServiceClient.httpx_client,
+                "post",
+                wraps=ServiceClient.httpx_client.post,
             ) as mock_post,
             patch.object(
                 ServiceClient.httpx_client,

--- a/tabpfn_client/tests/unit/test_service_wrapper.py
+++ b/tabpfn_client/tests/unit/test_service_wrapper.py
@@ -16,11 +16,9 @@ class TestUserAuthClient(unittest.TestCase):
     """
 
     def setUp(self):
-        ServiceClient().reset_authorization()
+        ServiceClient.reset_authorization()
 
     def tearDown(self):
-        ServiceClient().delete_instance()
-
         UserAuthenticationClient.CACHED_TOKEN_FILE.unlink(missing_ok=True)
 
     @with_mock_server()
@@ -32,13 +30,13 @@ class TestUserAuthClient(unittest.TestCase):
         )
 
         self.assertTrue(
-            UserAuthenticationClient(ServiceClient()).set_token_by_login(
+            UserAuthenticationClient.set_token_by_login(
                 "dummy_email", "dummy_password"
             )[0]
         )
 
         # assert token is set
-        self.assertEqual(dummy_token, ServiceClient().access_token)
+        self.assertEqual(dummy_token, ServiceClient.get_access_token())
 
     @with_mock_server()
     def test_set_token_by_invalid_login(self, mock_server):
@@ -48,13 +46,13 @@ class TestUserAuthClient(unittest.TestCase):
         )
         self.assertEqual(
             (False, "Incorrect email or password"),
-            UserAuthenticationClient(ServiceClient()).set_token_by_login(
+            UserAuthenticationClient.set_token_by_login(
                 "dummy_email", "dummy_password"
             ),
         )
 
         # assert token is not set
-        self.assertIsNone(ServiceClient().access_token)
+        self.assertIsNone(ServiceClient.get_access_token())
 
     @with_mock_server()
     def test_try_reusing_existing_token(self, mock_server):
@@ -68,17 +66,17 @@ class TestUserAuthClient(unittest.TestCase):
         mock_server.router.get(mock_server.endpoints.protected_root.path).respond(200)
 
         # assert no exception is raised
-        UserAuthenticationClient(ServiceClient()).try_reuse_existing_token()
+        UserAuthenticationClient.try_reuse_existing_token()
 
         # assert token is set
-        self.assertEqual(dummy_token, ServiceClient().access_token)
+        self.assertEqual(dummy_token, ServiceClient.get_access_token())
 
     def test_try_reusing_non_existing_token(self):
         # assert no exception is raised
-        UserAuthenticationClient(ServiceClient()).try_reuse_existing_token()
+        UserAuthenticationClient.try_reuse_existing_token()
 
         # assert token is not set
-        self.assertIsNone(ServiceClient().access_token)
+        self.assertIsNone(ServiceClient.get_access_token())
 
     @with_mock_server()
     def test_set_token_by_invalid_registration(self, mock_server):
@@ -88,7 +86,7 @@ class TestUserAuthClient(unittest.TestCase):
         )
         self.assertEqual(
             (False, "Password mismatch"),
-            UserAuthenticationClient(ServiceClient()).set_token_by_registration(
+            UserAuthenticationClient.set_token_by_registration(
                 "dummy_email",
                 "dummy_password",
                 "dummy_password",
@@ -103,7 +101,7 @@ class TestUserAuthClient(unittest.TestCase):
         )
 
         # assert token is not set
-        self.assertIsNone(ServiceClient().access_token)
+        self.assertIsNone(ServiceClient.get_access_token())
 
     @with_mock_server()
     def test_reset_cache_after_token_set(self, mock_server):
@@ -115,25 +113,23 @@ class TestUserAuthClient(unittest.TestCase):
 
         # mock authentication
         mock_server.router.get(mock_server.endpoints.protected_root.path).respond(200)
-        self.assertTrue(
-            UserAuthenticationClient(ServiceClient()).try_reuse_existing_token()
-        )
+        self.assertTrue(UserAuthenticationClient.try_reuse_existing_token())
 
         # assert token is set
-        self.assertEqual(dummy_token, ServiceClient().access_token)
+        self.assertEqual(dummy_token, ServiceClient.get_access_token())
 
         # reset cache
-        UserAuthenticationClient(ServiceClient()).reset_cache()
+        UserAuthenticationClient.reset_cache()
 
         # assert token is not set
-        self.assertIsNone(ServiceClient().access_token)
+        self.assertIsNone(ServiceClient.get_access_token())
 
     def test_reset_cache_without_token_set(self):
         # assert no exception is raised
-        UserAuthenticationClient(ServiceClient()).reset_cache()
+        UserAuthenticationClient.reset_cache()
 
         # assert token is not set
-        self.assertIsNone(ServiceClient().access_token)
+        self.assertIsNone(ServiceClient.get_access_token())
 
 
 class TestUserDataClient(unittest.TestCase):
@@ -156,7 +152,7 @@ class TestUserDataClient(unittest.TestCase):
             200, json=mock_summary
         )
 
-        self.assertEqual(mock_summary, UserDataClient().get_data_summary())
+        self.assertEqual(mock_summary, UserDataClient.get_data_summary())
 
     @with_mock_server()
     def test_download_all_data_accepts_empty_zip(self, mock_server):
@@ -173,7 +169,7 @@ class TestUserDataClient(unittest.TestCase):
         )
 
         # assert no exception is raised, and zip file is empty
-        zip_file_path = UserDataClient().download_all_data(Path("."))
+        zip_file_path = UserDataClient.download_all_data(Path("."))
         self.assertTrue(self._is_zip_file_empty(zip_file_path))
 
         # delete the zip file
@@ -194,7 +190,7 @@ class TestUserDataClient(unittest.TestCase):
         )
 
         # assert no exception is raised, and zip file is not empty
-        zip_file_path = UserDataClient().download_all_data(Path("."))
+        zip_file_path = UserDataClient.download_all_data(Path("."))
         self.assertFalse(self._is_zip_file_empty(zip_file_path))
 
         # delete the zip file
@@ -208,7 +204,7 @@ class TestUserDataClient(unittest.TestCase):
         )
 
         # assert no exception is raised
-        self.assertEqual([], UserDataClient().delete_dataset("dummy_uid"))
+        self.assertEqual([], UserDataClient.delete_dataset("dummy_uid"))
 
     @with_mock_server()
     def test_delete_datasets_accepts_uid_list(self, mock_server):
@@ -218,7 +214,7 @@ class TestUserDataClient(unittest.TestCase):
         )
 
         # assert no exception is raised
-        self.assertEqual(["dummy_uid"], UserDataClient().delete_dataset("dummy_uid"))
+        self.assertEqual(["dummy_uid"], UserDataClient.delete_dataset("dummy_uid"))
 
     @with_mock_server()
     def test_delete_all_datasets_accepts_empty_uid_list(self, mock_server):
@@ -228,7 +224,7 @@ class TestUserDataClient(unittest.TestCase):
         ).respond(200, json={"deleted_dataset_uids": []})
 
         # assert no exception is raised
-        self.assertEqual([], UserDataClient().delete_all_datasets())
+        self.assertEqual([], UserDataClient.delete_all_datasets())
 
     @with_mock_server()
     def test_delete_all_datasets_accepts_uid_list(self, mock_server):
@@ -238,11 +234,11 @@ class TestUserDataClient(unittest.TestCase):
         ).respond(200, json={"deleted_dataset_uids": ["dummy_uid"]})
 
         # assert no exception is raised
-        self.assertEqual(["dummy_uid"], UserDataClient().delete_all_datasets())
+        self.assertEqual(["dummy_uid"], UserDataClient.delete_all_datasets())
 
     @with_mock_server()
     @patch(
-        "tabpfn_client.service_wrapper.PromptAgent.prompt_confirm_password_for_user_account_deletion"
+        "tabpfn_client.prompt_agent.PromptAgent.prompt_confirm_password_for_user_account_deletion"
     )
     def test_delete_user_account_with_valid_password(
         self, mock_server, mock_prompt_confirm_password
@@ -256,11 +252,11 @@ class TestUserDataClient(unittest.TestCase):
         mock_prompt_confirm_password.return_value = "dummy_password"
 
         # assert no exception is raised
-        UserDataClient().delete_user_account()
+        UserDataClient.delete_user_account()
 
     @with_mock_server()
     @patch(
-        "tabpfn_client.service_wrapper.PromptAgent.prompt_confirm_password_for_user_account_deletion"
+        "tabpfn_client.prompt_agent.PromptAgent.prompt_confirm_password_for_user_account_deletion"
     )
     def test_delete_user_account_with_invalid_password(
         self, mock_server, mock_prompt_confirm_password
@@ -274,4 +270,4 @@ class TestUserDataClient(unittest.TestCase):
         mock_prompt_confirm_password.return_value = "dummy_password"
 
         # assert exception is raised
-        self.assertRaises(RuntimeError, UserDataClient().delete_user_account)
+        self.assertRaises(RuntimeError, UserDataClient.delete_user_account)

--- a/tabpfn_client/tests/unit/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_classifier.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import shutil
 import json
 
@@ -9,9 +9,8 @@ from sklearn.model_selection import train_test_split
 from sklearn.exceptions import NotFittedError
 
 from tabpfn_client import init, reset
-from tabpfn_client import estimator
 from tabpfn_client.estimator import TabPFNClassifier
-from tabpfn_client.service_wrapper import UserAuthenticationClient
+from tabpfn_client.service_wrapper import UserAuthenticationClient, InferenceClient
 from tabpfn_client.client import ServiceClient
 from tabpfn_client.tests.mock_tabpfn_server import with_mock_server
 from tabpfn_client.constants import CACHE_DIR
@@ -23,17 +22,13 @@ class TestTabPFNClassifierInit(unittest.TestCase):
 
     def setUp(self):
         # set up dummy data
+        reset()
         X, y = load_breast_cancer(return_X_y=True)
         self.X_train, self.X_test, self.y_train, self.y_test = train_test_split(
             X, y, test_size=0.33
         )
 
     def tearDown(self):
-        reset()
-
-        # remove singleton instance of ServiceClient
-        ServiceClient().delete_instance()
-
         # remove cache dir
         shutil.rmtree(CACHE_DIR, ignore_errors=True)
 
@@ -47,7 +42,7 @@ class TestTabPFNClassifierInit(unittest.TestCase):
         self, mock_server, mock_prompt_for_terms_and_cond, mock_prompt_and_set_token
     ):
         mock_prompt_and_set_token.side_effect = (
-            lambda user_auth_handler: user_auth_handler.set_token(self.dummy_token)
+            lambda: UserAuthenticationClient.set_token(self.dummy_token)
         )
 
         # mock server connection
@@ -67,14 +62,17 @@ class TestTabPFNClassifierInit(unittest.TestCase):
             content=f'data: {json.dumps({"event": "result", "data": {"classification": mock_predict_response, "test_set_uid": "6"}})}\n\n',
             headers={"Content-Type": "text/event-stream"},
         )
+        print(
+            f"{UserAuthenticationClient.CACHED_TOKEN_FILE.exists()=}, {ServiceClient.get_access_token()=}"
+        )
 
         init(use_server=True)
+        self.assertTrue(mock_prompt_and_set_token.called)
+        self.assertTrue(mock_prompt_for_terms_and_cond.called)
 
         tabpfn = TabPFNClassifier(n_estimators=10)
         self.assertRaises(NotFittedError, tabpfn.predict, self.X_test)
         tabpfn.fit(self.X_train, self.y_train)
-        self.assertTrue(mock_prompt_and_set_token.called)
-        self.assertTrue(mock_prompt_for_terms_and_cond.called)
 
         y_pred = tabpfn.predict(self.X_test)
         self.assertTrue(np.all(np.argmax(mock_predict_response, axis=1) == y_pred))
@@ -153,7 +151,7 @@ class TestTabPFNClassifierInit(unittest.TestCase):
         self.assertFalse(UserAuthenticationClient.CACHED_TOKEN_FILE.exists())
 
         # check if config is reset
-        self.assertFalse(estimator.config.g_tabpfn_config.is_initialized)
+        self.assertFalse(config.Config.is_initialized)
 
     @with_mock_server()
     @patch(
@@ -171,7 +169,7 @@ class TestTabPFNClassifierInit(unittest.TestCase):
 class TestTabPFNClassifierInference(unittest.TestCase):
     def setUp(self):
         # skip init
-        config.g_tabpfn_config.is_initialized = True
+        config.Config.is_initialized = True
 
     def tearDown(self):
         # undo setUp
@@ -221,19 +219,16 @@ class TestTabPFNClassifierInference(unittest.TestCase):
         tabpfn.classes_ = np.array([0, 1])
 
         # mock prediction
-        config.g_tabpfn_config.inference_handler = MagicMock()
-        config.g_tabpfn_config.inference_handler.predict = MagicMock(
-            return_value={"probas": np.random.rand(10, 2)}
-        )
-
-        tabpfn.predict(test_X)
+        with patch.object(InferenceClient, "predict") as mock_predict:
+            mock_predict.return_value = {"probas": np.random.rand(10, 2)}
+            tabpfn.predict(test_X)
 
 
 class TestTabPFNModelSelection(unittest.TestCase):
     def setUp(self):
         # skip init
-        config.g_tabpfn_config.is_initialized = True
-        config.g_tabpfn_config.use_server = True
+        config.Config.is_initialized = True
+        config.Config.use_server = True
 
     def tearDown(self):
         # undo setUp
@@ -287,21 +282,23 @@ class TestTabPFNModelSelection(unittest.TestCase):
 
         tabpfn = TabPFNClassifier(model="gn2p4bpt")
 
-        # Mock the inference handler
-        config.g_tabpfn_config.inference_handler = MagicMock()
-        config.g_tabpfn_config.inference_handler.fit = MagicMock()
-        config.g_tabpfn_config.inference_handler.predict = MagicMock(
-            return_value={"probas": np.random.rand(10, 2)}
-        )
+        # Mock the inference client
+        with patch.object(InferenceClient, "predict") as mock_predict:
+            mock_predict.return_value = {"probas": np.random.rand(10, 2)}
 
-        # Fit and predict
-        tabpfn.fit(X, y)
-        tabpfn.predict_proba(X)
+            with patch.object(InferenceClient, "fit") as mock_fit:
+                mock_fit.return_value = "dummy_uid"
 
-        # Verify the model path was correctly passed to predict
-        predict_kwargs = config.g_tabpfn_config.inference_handler.predict.call_args[1]
-        expected_model_path = (
-            f"{TabPFNClassifier._BASE_PATH}_classification_gn2p4bpt.ckpt"
-        )
+                # Fit and predict
+                tabpfn.fit(X, y)
+                tabpfn.predict_proba(X)
 
-        self.assertEqual(predict_kwargs["config"]["model_path"], expected_model_path)
+                # Verify the model path was correctly passed to predict
+                predict_kwargs = mock_predict.call_args[1]
+                expected_model_path = (
+                    f"{TabPFNClassifier._BASE_PATH}_classification_gn2p4bpt.ckpt"
+                )
+
+                self.assertEqual(
+                    predict_kwargs["config"]["model_path"], expected_model_path
+                )


### PR DESCRIPTION
### Change Description

I reworked a lot of our logic in the client to achieve the following:

1. be able to log out

in our current client i still had the following:
```python
In [1]: import tabpfn_client

In [2]: tabpfn_client.init()
  Welcome Back! Found existing access token, reusing it for authentication.

In [3]: tabpfn_client.reset()

In [4]: tabpfn_client.init()
  Welcome Back! Found existing access token, reusing it for authentication.
```

2. easier to understand the state. the config is now very reduced and all 4 service classes are singletons

3. the api for the tokens got simpler, see [README.md](README.md)

4. i did some typing fixes


**If you used new dependencies: Did you add them to `requirements.txt`?**
no

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**

@noahho @liam-sbhoo 

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**

No.

**Does this PR break the user interface? If so, why?**

Slightly, the part with setting the access tokens, which is very new, though.

---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
