### PR TITLE
Send task to fit endpoint, not just predict (for CAAFE)

### DIFF
--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -278,7 +278,7 @@ class ServiceClient:
                         raise RuntimeError(
                             "Train set data is required to re-upload but was not provided."
                         )
-                    train_set_uid = self.upload_train_set(X_train, y_train)
+                    train_set_uid = self.fit(X_train, y_train)
                     params["train_set_uid"] = train_set_uid
                     cached_test_set_uid = None
                 else:

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -169,7 +169,7 @@ class ServiceClient:
     def is_initialized(self):
         return self.access_token is not None and self.access_token != ""
 
-    def upload_train_set(self, X, y) -> str:
+    def fit(self, X, y) -> str:
         """
         Upload a train set to server and return the train set UID if successful.
 
@@ -200,7 +200,7 @@ class ServiceClient:
             return cached_dataset_uid
 
         response = self.httpx_client.post(
-            url=self.server_endpoints.upload_train_set.path,
+            url=self.server_endpoints.fit.path,
             files=common_utils.to_httpx_post_file_format(
                 [
                     ("x_file", "x_train_filename", X_serialized),
@@ -209,7 +209,7 @@ class ServiceClient:
             ),
         )
 
-        self._validate_response(response, "upload_train_set")
+        self._validate_response(response, "fit")
 
         train_set_uid = response.json()["train_set_uid"]
         self.dataset_uid_cache_manager.add_dataset_uid(dataset_hash, train_set_uid)

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -169,7 +169,7 @@ class ServiceClient:
     def is_initialized(self):
         return self.access_token is not None and self.access_token != ""
 
-    def fit(self, X, y) -> str:
+    def fit(self, X, y, task: Literal["classification", "regression"]) -> str:
         """
         Upload a train set to server and return the train set UID if successful.
 
@@ -179,6 +179,8 @@ class ServiceClient:
             The training input samples.
         y : array-like of shape (n_samples,) or (n_samples, n_outputs)
             The target values.
+        task : Literal["classification", "regression"]
+            The task to perform.
 
         Returns
         -------
@@ -199,6 +201,8 @@ class ServiceClient:
         if cached_dataset_uid:
             return cached_dataset_uid
 
+        params = {"task": task}
+
         response = self.httpx_client.post(
             url=self.server_endpoints.fit.path,
             files=common_utils.to_httpx_post_file_format(
@@ -207,6 +211,7 @@ class ServiceClient:
                     ("y_file", "y_train_filename", y_serialized),
                 ]
             ),
+            params=params,
         )
 
         self._validate_response(response, "fit")

--- a/tabpfn_client/estimator.py
+++ b/tabpfn_client/estimator.py
@@ -251,7 +251,9 @@ class TabPFNClassifier(BaseEstimator, ClassifierMixin, TabPFNModelSelection):
         self._validate_targets_and_classes(y)
 
         if config.g_tabpfn_config.use_server:
-            self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
+            self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(
+                X, y, task="classification"
+            )
             self.last_train_X = X
             self.last_train_y = y
             self.fitted_ = True
@@ -406,7 +408,9 @@ class TabPFNRegressor(BaseEstimator, RegressorMixin, TabPFNModelSelection):
         validate_data_size(X, y)
 
         if config.g_tabpfn_config.use_server:
-            self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(X, y)
+            self.last_train_set_uid = config.g_tabpfn_config.inference_handler.fit(
+                X, y, task="regression"
+            )
             self.last_train_X = X
             self.last_train_y = y
             self.fitted_ = True

--- a/tabpfn_client/server_config.yaml
+++ b/tabpfn_client/server_config.yaml
@@ -64,6 +64,11 @@ endpoints:
     methods: [ "POST" ]
     description: "Upload train set"
 
+  fit:
+    path: "/fit/"
+    methods: [ "POST" ]
+    description: "Fit"
+
   predict:
     path: "/predict/"
     methods: [ "POST" ]

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -186,7 +186,7 @@ class InferenceClient(ServiceClientWrapper):
                 "Please Note: The email verification token expires in 30 minutes."
             )
 
-        return self.service_client.upload_train_set(X, y)
+        return self.service_client.fit(X, y)
 
     def predict(
         self,

--- a/tabpfn_client/service_wrapper.py
+++ b/tabpfn_client/service_wrapper.py
@@ -47,6 +47,7 @@ class UserAuthenticationClient(ServiceClientWrapper):
         is_created, message, access_token = self.service_client.register(
             email, password, password_confirm, validation_link, additional_info
         )
+
         if access_token is not None:
             self.set_token(access_token)
         return is_created, message
@@ -179,14 +180,14 @@ class InferenceClient(ServiceClientWrapper):
     def __init__(self, service_client=ServiceClient()):
         super().__init__(service_client)
 
-    def fit(self, X, y) -> str:
+    def fit(self, X, y, task: Literal["classification", "regression"]) -> str:
         if not self.service_client.is_initialized:
             raise RuntimeError(
                 "Dear TabPFN User, please initialize the client first by verifying your E-mail address sent to your registered E-mail account."
                 "Please Note: The email verification token expires in 30 minutes."
             )
 
-        return self.service_client.fit(X, y)
+        return self.service_client.fit(X, y, task)
 
     def predict(
         self,

--- a/tabpfn_client/tests/integration/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/integration/test_tabpfn_classifier.py
@@ -40,7 +40,7 @@ class TestTabPFNClassifier(unittest.TestCase):
         tabpfn = TabPFNClassifier()
 
         # mock fitting
-        mock_server.router.post(mock_server.endpoints.upload_train_set.path).respond(
+        mock_server.router.post(mock_server.endpoints.fit.path).respond(
             200, json={"train_set_uid": "5"}
         )
         tabpfn.fit(self.X_train, self.y_train)

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -289,10 +289,7 @@ class TestServiceClient(unittest.TestCase):
         ) as mock_post:
             # Mock responses
             def side_effect(*args, **kwargs):
-                if (
-                    kwargs.get("url")
-                    == self.client.server_endpoints.fit.path
-                ):
+                if kwargs.get("url") == self.client.server_endpoints.fit.path:
                     response = Mock()
                     response.status_code = 200
                     response.json.return_value = {
@@ -329,9 +326,7 @@ class TestServiceClient(unittest.TestCase):
             self.assertTrue(np.array_equal(pred1["probas"], pred2["probas"]))
 
             # The predict endpoint should have been called twice
-            self.assertEqual(
-                mock_post.call_count, 3
-            )  # 1 for fit, 2 for predict
+            self.assertEqual(mock_post.call_count, 3)  # 1 for fit, 2 for predict
 
             # Check that the test set was uploaded only once (first predict call)
             upload_calls = [
@@ -354,10 +349,7 @@ class TestServiceClient(unittest.TestCase):
         ) as mock_post:
             # Mock responses with side effects to simulate invalid cached UIDs
             def side_effect(*args, **kwargs):
-                if (
-                    kwargs.get("url")
-                    == self.client.server_endpoints.fit.path
-                ):
+                if kwargs.get("url") == self.client.server_endpoints.fit.path:
                     response = Mock()
                     response.status_code = 200
                     response.json.return_value = {
@@ -408,16 +400,13 @@ class TestServiceClient(unittest.TestCase):
             self.assertTrue(np.array_equal(pred["probas"], [1, 2, 3]))
 
             # The predict endpoint should have been called twice due to retry
-            self.assertEqual(
-                mock_post.call_count, 4
-            )  # 1 fit + 2 predict + 1 re-upload
+            self.assertEqual(mock_post.call_count, 4)  # 1 fit + 2 predict + 1 re-upload
 
             # Ensure that fit was called again (re-upload)
             upload_calls = [
                 call
                 for call in mock_post.call_args_list
-                if call.kwargs.get("url")
-                == self.client.server_endpoints.fit.path
+                if call.kwargs.get("url") == self.client.server_endpoints.fit.path
             ]
             self.assertEqual(len(upload_calls), 2)
 

--- a/tabpfn_client/tests/unit/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_classifier.py
@@ -51,7 +51,7 @@ class TestTabPFNClassifierInit(unittest.TestCase):
 
         # mock server connection
         mock_server.router.get(mock_server.endpoints.root.path).respond(200)
-        mock_server.router.post(mock_server.endpoints.upload_train_set.path).respond(
+        mock_server.router.post(mock_server.endpoints.fit.path).respond(
             200, json={"train_set_uid": "5"}
         )
 

--- a/tabpfn_client/tests/unit/test_tabpfn_regressor.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_regressor.py
@@ -51,7 +51,7 @@ class TestTabPFNRegressorInit(unittest.TestCase):
 
         # mock server connection
         mock_server.router.get(mock_server.endpoints.root.path).respond(200)
-        mock_server.router.post(mock_server.endpoints.upload_train_set.path).respond(
+        mock_server.router.post(mock_server.endpoints.fit.path).respond(
             200, json={"train_set_uid": "5"}
         )
         mock_server.router.get(


### PR DESCRIPTION
### Change Description

*Try to be precise. You can additionally add comments to your PR, this might help the reviewer a lot.*
Builds on #47. We need this change for https://github.com/automl/tabpfn-server/pull/88

**If you used new dependencies: Did you add them to `requirements.txt`?**

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**

**Does this PR break the user interface? If so, why?**

---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
