### PR TITLE
Make prediction async

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tabpfn-client"
-version = "0.0.24"
+version = "0.0.25"
 requires-python = ">=3.10"
 dynamic = ["dependencies", "optional-dependencies"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas>=1.3.0
 password-strength
 scikit-learn>=1.5.2
 cityhash
+sseclient-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ password-strength
 scikit-learn>=1.5.2
 cityhash
 sseclient-py
+tqdm

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -317,7 +317,9 @@ class ServiceClient:
                             elif data["error_class"] == "ValueError":
                                 raise ValueError(data["detail"])
                             else:
-                                raise RuntimeError(data["detail"])
+                                raise RuntimeError(
+                                    data["error_class"] + ": " + data["detail"]
+                                )
                 break
             except RuntimeError as e:
                 error_message = str(e)

--- a/tabpfn_client/client.py
+++ b/tabpfn_client/client.py
@@ -297,7 +297,9 @@ class ServiceClient:
 
                     for event in client.events():
                         data = json.loads(event.data)
-                        if data["event"] == "duration_estimate":
+                        if data["event"] == "message":
+                            print(data["data"])
+                        elif data["event"] == "estimated_time_to_answer":
                             duration = float(data["data"])
                             print(f"Duration estimate: {duration} seconds")
                             progress_thread = threading.Thread(target=run_progress)

--- a/tabpfn_client/tests/integration/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/integration/test_tabpfn_classifier.py
@@ -45,15 +45,12 @@ class TestTabPFNClassifier(unittest.TestCase):
         )
         tabpfn.fit(self.X_train, self.y_train)
 
-        # mock prediction
+        # mock prediction with SSE
+        probas = np.random.rand(len(self.X_test), len(np.unique(self.y_train))).tolist()
         mock_server.router.post(mock_server.endpoints.predict.path).respond(
             200,
-            json={
-                "classification": np.random.rand(
-                    len(self.X_test), len(np.unique(self.y_train))
-                ).tolist(),
-                "test_set_uid": "6",
-            },
+            content=f'data: {{"event": "result", "data": {{"classification": {probas}, "test_set_uid": "6"}}}}\n\n',
+            headers={"Content-Type": "text/event-stream"},
         )
         pred = tabpfn.predict(self.X_test)
         self.assertEqual(pred.shape[0], self.X_test.shape[0])

--- a/tabpfn_client/tests/unit/test_client.py
+++ b/tabpfn_client/tests/unit/test_client.py
@@ -287,9 +287,16 @@ class TestServiceClient(unittest.TestCase):
         self.client.authorize("dummy_access_token")
 
         # Mock the upload_train_set and predict endpoints
-        with patch.object(
-            self.client.httpx_client, "post", wraps=self.client.httpx_client.post
-        ) as mock_post:
+        with (
+            patch.object(
+                self.client.httpx_client, "post", wraps=self.client.httpx_client.post
+            ) as mock_post,
+            patch.object(
+                self.client.httpx_client,
+                "stream",
+                wraps=self.client.httpx_client.stream,
+            ) as mock_stream,
+        ):
             # Mock responses
             def side_effect(*args, **kwargs):
                 if (
@@ -309,15 +316,18 @@ class TestServiceClient(unittest.TestCase):
                     response.iter_bytes = Mock(
                         return_value=iter(
                             [
-                                'data: {"event": "result", "data": {"probas": [1, 2, 3], "test_set_uid": "dummy_test_set_uid"}}\n\n'.encode()
+                                'data: {"event": "result", "data": {"classification": [1, 2, 3], "test_set_uid": "dummy_test_set_uid"}}\n\n'.encode()
                             ]
                         )
                     )
+                    response.__enter__ = Mock(return_value=response)
+                    response.__exit__ = Mock(return_value=None)
                     return response
                 else:
                     return Mock(status_code=404)
 
             mock_post.side_effect = side_effect
+            mock_stream.side_effect = side_effect
 
             # Upload train set
             train_set_uid = self.client.upload_train_set(self.X_train, self.y_train)
@@ -337,16 +347,14 @@ class TestServiceClient(unittest.TestCase):
 
             # The predict endpoint should have been called twice
             self.assertEqual(
-                mock_post.call_count, 3
+                mock_post.call_count + mock_stream.call_count, 3
             )  # 1 for upload_train_set, 2 for predict
 
             # Check that the test set was uploaded only once (first predict call)
             upload_calls = [
-                call for call in mock_post.call_args_list if "files" in call[1]
+                call for call in mock_stream.call_args_list if "files" in call[1]
             ]
-            self.assertEqual(
-                len(upload_calls), 2
-            )  # 1 for train set, 1 for test set upload
+            self.assertEqual(len(upload_calls), 1)
 
     def test_predict_with_invalid_cached_uids(self):
         """
@@ -356,9 +364,16 @@ class TestServiceClient(unittest.TestCase):
         self.client.authorize("dummy_access_token")
 
         # Mock the upload_train_set and predict endpoints
-        with patch.object(
-            self.client.httpx_client, "post", wraps=self.client.httpx_client.post
-        ) as mock_post:
+        with (
+            patch.object(
+                self.client.httpx_client, "post", wraps=self.client.httpx_client.post
+            ) as mock_post,
+            patch.object(
+                self.client.httpx_client,
+                "stream",
+                wraps=self.client.httpx_client.stream,
+            ) as mock_stream,
+        ):
             # Mock responses with side effects to simulate invalid cached UIDs
             def side_effect(*args, **kwargs):
                 if (
@@ -379,14 +394,23 @@ class TestServiceClient(unittest.TestCase):
                         response.json.return_value = {
                             "detail": "Invalid train or test set uid"
                         }
+                        response.__enter__ = Mock(return_value=response)
+                        response.__exit__ = Mock(return_value=None)
                         return response
                     else:
+                        # Successful prediction after re-upload
                         response = Mock()
                         response.status_code = 200
-                        response.json.return_value = {
-                            "classification": [1, 2, 3],
-                            "test_set_uid": "new_dummy_test_set_uid",
-                        }
+                        response.headers = {"Content-Type": "text/event-stream"}
+                        response.iter_bytes = Mock(
+                            return_value=iter(
+                                [
+                                    'data: {"event": "result", "data": {"classification": [1, 2, 3], "test_set_uid": "new_dummy_test_set_uid"}}\n\n'.encode()
+                                ]
+                            )
+                        )
+                        response.__enter__ = Mock(return_value=response)
+                        response.__exit__ = Mock(return_value=None)
                         return response
                 else:
                     return Mock(status_code=404)
@@ -398,6 +422,7 @@ class TestServiceClient(unittest.TestCase):
                 return side_effect(*args, **kwargs)
 
             mock_post.side_effect = side_effect_counter
+            mock_stream.side_effect = side_effect_counter
 
             # Upload train set
             train_set_uid = self.client.upload_train_set(self.X_train, self.y_train)
@@ -416,7 +441,7 @@ class TestServiceClient(unittest.TestCase):
 
             # The predict endpoint should have been called twice due to retry
             self.assertEqual(
-                mock_post.call_count, 4
+                mock_post.call_count + mock_stream.call_count, 4
             )  # 1 upload_train_set + 2 predict + 1 re-upload
 
             # Ensure that upload_train_set was called again (re-upload)

--- a/tabpfn_client/tests/unit/test_tabpfn_classifier.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_classifier.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import shutil
+import json
 
 import numpy as np
 from sklearn.datasets import load_breast_cancer
@@ -62,7 +63,9 @@ class TestTabPFNClassifierInit(unittest.TestCase):
         mock_predict_response = [[1, 0.0], [0.9, 0.1], [0.01, 0.99]]
         predict_route = mock_server.router.post(mock_server.endpoints.predict.path)
         predict_route.respond(
-            200, json={"classification": mock_predict_response, "test_set_uid": "6"}
+            200,
+            content=f'data: {json.dumps({"event": "result", "data": {"classification": mock_predict_response, "test_set_uid": "6"}})}\n\n',
+            headers={"Content-Type": "text/event-stream"},
         )
 
         init(use_server=True)

--- a/tabpfn_client/tests/unit/test_tabpfn_regressor.py
+++ b/tabpfn_client/tests/unit/test_tabpfn_regressor.py
@@ -15,6 +15,7 @@ from tabpfn_client.client import ServiceClient
 from tabpfn_client.tests.mock_tabpfn_server import with_mock_server
 from tabpfn_client.constants import CACHE_DIR
 from tabpfn_client import config
+import json
 
 
 class TestTabPFNRegressorInit(unittest.TestCase):
@@ -65,7 +66,9 @@ class TestTabPFNRegressorInit(unittest.TestCase):
         }
         predict_route = mock_server.router.post(mock_server.endpoints.predict.path)
         predict_route.respond(
-            200, json={"regression": mock_predict_response, "test_set_uid": "6"}
+            200,
+            content=f'data: {json.dumps({"event": "result", "data": {"regression": mock_predict_response, "test_set_uid": "6"}})}\n\n',
+            headers={"Content-Type": "text/event-stream"},
         )
 
         init(use_server=True)


### PR DESCRIPTION
### Change Description

*Try to be precise. You can additionally add comments to your PR, this might help the reviewer a lot.*

This PR involves the client side for making predictions async. Please also check the corresponding [Server PR](https://github.com/automl/tabpfn-server/pull/92). On the client side, we only need updates in client.py. We now send streaming requests and basically just loop over all messages we receive. Currently, if a duration estimation is received, I print the estimated duration and then show a progress bar that runs for this estimated duration. The question is now if we want to keep this initial print of estimated duration and if we might also want to add a message that is printed if the prediction is taking longer than expected.

**If you used new dependencies: Did you add them to `requirements.txt`?**

Yes. Should I also add version numbers?

**Who did you ping on Mattermost to review your PR? Please ping that person again whenever you are ready for another review.**

@noahho 

## Breaking changes

If you made any breaking changes, please update the version number.
Breaking changes are totally fine, we just need to make sure to keep the users informed and the server in sync.

**Does this PR break the API? If so, what is the corresponding server commit?**

Yes, PR mentioned above

**Does this PR break the user interface? If so, why?**

---
*Please do not mark comments/conversations as resolved unless you are the assigned reviewer. This helps maintain clarity during the review process.*
